### PR TITLE
Add Version to ProviderInfo

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -81,6 +81,7 @@ func Provider() tfbridge.ProviderInfo {
 		Publisher:         "pulumiverse",
 		LogoURL:           "https://raw.githubusercontent.com/pulumiverse/pulumi-grafana/main/assets/grafana.png", // nolint[:lll]
 		PluginDownloadURL: "github://api.github.com/pulumiverse",
+		Version:           version.Version,
 		Description:       "A Pulumi package for creating and managing grafana.",
 		Keywords:          []string{"pulumi", "grafana", "pulumiverse"},
 		License:           "Apache-2.0",


### PR DESCRIPTION
As of v0.4.0 the Grafana Pulumi package has been failing to execute successfully. 

Before this change you would see the following error

```
Diagnostics:
  pulumi:providers:grafana (default_0_4_0_github_/api.github.com/pulumiverse):
    error: could not read plugin [/Users/teddy/.pulumi/plugins/resource-grafana-v0.4.0/pulumi-resource-grafana] stdout: EOF

  pulumi:pulumi:Stack (pulumi-test-dev):
    error: fatal: failed to Init GRPC to register RPC handlers: failed to create resource provider: ProviderInfo needs a semver-compatible version string, got info.Version=""
```

Fixes #137 