### PR TITLE
chore: Update bridge-metadata.json for PagerDuty URL

### DIFF
--- a/provider/cmd/pulumi-resource-grafana/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-grafana/bridge-metadata.json
@@ -2384,6 +2384,7 @@
                 "sendTagsAs": "send_tags_as"
             },
             "grafana:index/ContactPointPagerduty:ContactPointPagerduty": {
+                "url": "url",
                 "clientUrl": "client_url",
                 "disableResolveMessage": "disable_resolve_message",
                 "integrationKey": "integration_key"


### PR DESCRIPTION
This PR will add an option to set the PagerDuty URL. 

Based on the Terraform Example [_acc_receiver_types.tf](https://github.com/grafana/terraform-provider-grafana/blob/f70ff2dfe12b48f560012a42a81bb94472565a8c/examples/resources/grafana_contact_point/_acc_receiver_types.tf#L81)

I hope this is correct to implement. In the end it should add the option to set the PagerDuty URL.