### PR TITLE
Improved example

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -15,9 +15,35 @@ The Grafana provider must be configured with credentials to deploy and update re
 ```typescript
 import * as grafana from "@pulumiverse/grafana";
 
-const sa = new grafana.ServiceAccount("example", {
-    role: "Viewer",
-})
+const stack = new grafana.cloud.Stack("stack", {
+    name: "<stack-name>",
+    slug: "<stack-name>",
+    // Regions https://grafana.com/api/stack-regions
+    regionSlug: "<region>",
+});
+
+const serviceAccount = new grafana.cloud.StackServiceAccount("serviceAccount", {
+    stackSlug: stack.slug,
+    name: "Service account",
+    role: "Admin",
+});
+
+const serviceAccountToken = new grafana.cloud.StackServiceAccountToken("serviceAccountToken", {
+    stackSlug: stack.slug,
+    name: "Service account token",
+    serviceAccountId: serviceAccount.id,
+});
+
+const serviceAccountProvider = new grafana.Provider("serviceAccountProvider", {
+    auth: serviceAccountToken.key,
+    url: stack.url.apply((url) => url as string),
+});
+
+const testFolder = new grafana.oss.Folder(
+    "folder",
+    { title: "Folder title" },
+    { provider: serviceAccountProvider }
+);
 
 ```
 

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -51,6 +51,8 @@ Once you have provisioned these credentials, you can set environment variables t
 {{% choosable os linux %}}
 
 ```bash
+$ export GRAFANA_CLOUD_ACCESS_POLICY_TOKEN=<GRAFANA_CLOUD_ACCESS_POLICY_TOKEN>
+
 $ export GRAFANA_URL=<GRAFANA_URL>
 $ export GRAFANA_AUTH=<GRAFANA_AUTH>
 ```
@@ -60,6 +62,8 @@ $ export GRAFANA_AUTH=<GRAFANA_AUTH>
 {{% choosable os macos %}}
 
 ```bash
+$ export GRAFANA_CLOUD_ACCESS_POLICY_TOKEN=<GRAFANA_CLOUD_ACCESS_POLICY_TOKEN>
+
 $ export GRAFANA_URL=<GRAFANA_URL>
 $ export GRAFANA_AUTH=<GRAFANA_AUTH>
 ```
@@ -69,6 +73,8 @@ $ export GRAFANA_AUTH=<GRAFANA_AUTH>
 {{% choosable os windows %}}
 
 ```powershell
+> $env:GRAFANA_CLOUD_ACCESS_POLICY_TOKEN = "<GRAFANA_CLOUD_ACCESS_POLICY_TOKEN>"
+
 > $env:GRAFANA_URL = "<GRAFANA_URL>"
 > $env:GRAFANA_AUTH = "<GRAFANA_AUTH>"
 ```


### PR DESCRIPTION
Updated example to match examples given by grafana and terraform docs. Grafana cloud setup is unintuitive without an example

https://grafana.com/docs/grafana-cloud/developer-resources/infrastructure-as-code/terraform/terraform-cloud-stack/
https://registry.terraform.io/providers/grafana/grafana/latest/docs
