### PR TITLE
Upgrade terraform-provider-grafana to v3.23.0

### DIFF
--- a/provider/cmd/pulumi-resource-grafana/schema.json
+++ b/provider/cmd/pulumi-resource-grafana/schema.json
@@ -1459,6 +1459,14 @@
                     "type": "string",
                     "description": "Templated title of the message.\n"
                 },
+                "tlsConfig": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Allows configuring TLS for the webhook notifier.\n",
+                    "secret": true
+                },
                 "uid": {
                     "type": "string",
                     "description": "The UID of the contact point.\n"
@@ -5133,6 +5141,14 @@
                 "title": {
                     "type": "string",
                     "description": "Templated title of the message.\n"
+                },
+                "tlsConfig": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Allows configuring TLS for the webhook notifier.\n",
+                    "secret": true
                 },
                 "uid": {
                     "type": "string",
@@ -15629,7 +15645,7 @@
             ]
         },
         "grafana:experimental/appsDashboard:AppsDashboard": {
-            "description": "Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.\n",
+            "description": "Manages Grafana dashboards using the new Grafana APIs.\n\n* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)\n* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)\n",
             "properties": {
                 "metadata": {
                     "$ref": "#/types/grafana:experimental/AppsDashboardMetadata:AppsDashboardMetadata",
@@ -15678,7 +15694,7 @@
             }
         },
         "grafana:experimental/appsPlaylistV0Alpha1:AppsPlaylistV0Alpha1": {
-            "description": "Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.\n",
+            "description": "Manages Grafana playlists using the new Grafana APIs.\n\n* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)\n* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)\n",
             "properties": {
                 "metadata": {
                     "$ref": "#/types/grafana:experimental/AppsPlaylistV0Alpha1Metadata:AppsPlaylistV0Alpha1Metadata",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/grafana/terraform-provider-grafana/v3 v3.22.4
+	github.com/grafana/terraform-provider-grafana/v3 v3.23.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.110.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1952,8 +1952,8 @@ github.com/grafana/synthetic-monitoring-agent v0.34.2 h1:qGrkGapITHdRBb5oCq7tkqj
 github.com/grafana/synthetic-monitoring-agent v0.34.2/go.mod h1:BVomev3uKqc5XZEWI1bxodPIAhtkcr6U5urtM8NV8e0=
 github.com/grafana/synthetic-monitoring-api-go-client v0.11.0 h1:C/LMuhY9USNXRVhzQ3S09C0rSyAwCUssCp3WOShLN5I=
 github.com/grafana/synthetic-monitoring-api-go-client v0.11.0/go.mod h1:eapoDTSZLpj+p//C15C/IUJY4PnIWWf8jb/Ui2rj4Pg=
-github.com/grafana/terraform-provider-grafana/v3 v3.22.4 h1:cD6uy7TXa6A7Yq2syAmwDjwFQBpbqV5O+rgYzxJAzrA=
-github.com/grafana/terraform-provider-grafana/v3 v3.22.4/go.mod h1:u0zMIq0SizIGWzD2r2nQH+e9ZOh/c6RAPgKj+MBX7SY=
+github.com/grafana/terraform-provider-grafana/v3 v3.23.0 h1:dU0rMohZ8C4cGVTNJXbQGeyis/rzjYyg9nLZMOydcGQ=
+github.com/grafana/terraform-provider-grafana/v3 v3.23.0/go.mod h1:u0zMIq0SizIGWzD2r2nQH+e9ZOh/c6RAPgKj+MBX7SY=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdixfIJjVzuUJdnv+5xsPutog=

--- a/sdk/dotnet/Alerting/Inputs/ContactPointWebhookArgs.cs
+++ b/sdk/dotnet/Alerting/Inputs/ContactPointWebhookArgs.cs
@@ -103,6 +103,22 @@ namespace Pulumiverse.Grafana.Alerting.Inputs
         [Input("title")]
         public Input<string>? Title { get; set; }
 
+        [Input("tlsConfig")]
+        private InputMap<string>? _tlsConfig;
+
+        /// <summary>
+        /// Allows configuring TLS for the webhook notifier.
+        /// </summary>
+        public InputMap<string> TlsConfig
+        {
+            get => _tlsConfig ?? (_tlsConfig = new InputMap<string>());
+            set
+            {
+                var emptySecret = Output.CreateSecret(ImmutableDictionary.Create<string, string>());
+                _tlsConfig = Output.All(value, emptySecret).Apply(v => v[0]);
+            }
+        }
+
         /// <summary>
         /// The UID of the contact point.
         /// </summary>

--- a/sdk/dotnet/Alerting/Inputs/ContactPointWebhookGetArgs.cs
+++ b/sdk/dotnet/Alerting/Inputs/ContactPointWebhookGetArgs.cs
@@ -103,6 +103,22 @@ namespace Pulumiverse.Grafana.Alerting.Inputs
         [Input("title")]
         public Input<string>? Title { get; set; }
 
+        [Input("tlsConfig")]
+        private InputMap<string>? _tlsConfig;
+
+        /// <summary>
+        /// Allows configuring TLS for the webhook notifier.
+        /// </summary>
+        public InputMap<string> TlsConfig
+        {
+            get => _tlsConfig ?? (_tlsConfig = new InputMap<string>());
+            set
+            {
+                var emptySecret = Output.CreateSecret(ImmutableDictionary.Create<string, string>());
+                _tlsConfig = Output.All(value, emptySecret).Apply(v => v[0]);
+            }
+        }
+
         /// <summary>
         /// The UID of the contact point.
         /// </summary>

--- a/sdk/dotnet/Alerting/Outputs/ContactPointWebhook.cs
+++ b/sdk/dotnet/Alerting/Outputs/ContactPointWebhook.cs
@@ -55,6 +55,10 @@ namespace Pulumiverse.Grafana.Alerting.Outputs
         /// </summary>
         public readonly string? Title;
         /// <summary>
+        /// Allows configuring TLS for the webhook notifier.
+        /// </summary>
+        public readonly ImmutableDictionary<string, string>? TlsConfig;
+        /// <summary>
         /// The UID of the contact point.
         /// </summary>
         public readonly string? Uid;
@@ -85,6 +89,8 @@ namespace Pulumiverse.Grafana.Alerting.Outputs
 
             string? title,
 
+            ImmutableDictionary<string, string>? tlsConfig,
+
             string? uid,
 
             string url)
@@ -99,6 +105,7 @@ namespace Pulumiverse.Grafana.Alerting.Outputs
             Message = message;
             Settings = settings;
             Title = title;
+            TlsConfig = tlsConfig;
             Uid = uid;
             Url = url;
         }

--- a/sdk/dotnet/Experimental/AppsDashboard.cs
+++ b/sdk/dotnet/Experimental/AppsDashboard.cs
@@ -11,7 +11,10 @@ using Pulumi;
 namespace Pulumiverse.Grafana.Experimental
 {
     /// <summary>
-    /// Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+    /// Manages Grafana dashboards using the new Grafana APIs.
+    /// 
+    /// * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+    /// * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
     /// </summary>
     [GrafanaResourceType("grafana:experimental/appsDashboard:AppsDashboard")]
     public partial class AppsDashboard : global::Pulumi.CustomResource

--- a/sdk/dotnet/Experimental/AppsPlaylistV0Alpha1.cs
+++ b/sdk/dotnet/Experimental/AppsPlaylistV0Alpha1.cs
@@ -11,7 +11,10 @@ using Pulumi;
 namespace Pulumiverse.Grafana.Experimental
 {
     /// <summary>
-    /// Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+    /// Manages Grafana playlists using the new Grafana APIs.
+    /// 
+    /// * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+    /// * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
     /// </summary>
     [GrafanaResourceType("grafana:experimental/appsPlaylistV0Alpha1:AppsPlaylistV0Alpha1")]
     public partial class AppsPlaylistV0Alpha1 : global::Pulumi.CustomResource

--- a/sdk/dotnet/Inputs/ContactPointWebhookArgs.cs
+++ b/sdk/dotnet/Inputs/ContactPointWebhookArgs.cs
@@ -103,6 +103,22 @@ namespace Pulumiverse.Grafana.Inputs
         [Input("title")]
         public Input<string>? Title { get; set; }
 
+        [Input("tlsConfig")]
+        private InputMap<string>? _tlsConfig;
+
+        /// <summary>
+        /// Allows configuring TLS for the webhook notifier.
+        /// </summary>
+        public InputMap<string> TlsConfig
+        {
+            get => _tlsConfig ?? (_tlsConfig = new InputMap<string>());
+            set
+            {
+                var emptySecret = Output.CreateSecret(ImmutableDictionary.Create<string, string>());
+                _tlsConfig = Output.All(value, emptySecret).Apply(v => v[0]);
+            }
+        }
+
         /// <summary>
         /// The UID of the contact point.
         /// </summary>

--- a/sdk/dotnet/Inputs/ContactPointWebhookGetArgs.cs
+++ b/sdk/dotnet/Inputs/ContactPointWebhookGetArgs.cs
@@ -103,6 +103,22 @@ namespace Pulumiverse.Grafana.Inputs
         [Input("title")]
         public Input<string>? Title { get; set; }
 
+        [Input("tlsConfig")]
+        private InputMap<string>? _tlsConfig;
+
+        /// <summary>
+        /// Allows configuring TLS for the webhook notifier.
+        /// </summary>
+        public InputMap<string> TlsConfig
+        {
+            get => _tlsConfig ?? (_tlsConfig = new InputMap<string>());
+            set
+            {
+                var emptySecret = Output.CreateSecret(ImmutableDictionary.Create<string, string>());
+                _tlsConfig = Output.All(value, emptySecret).Apply(v => v[0]);
+            }
+        }
+
         /// <summary>
         /// The UID of the contact point.
         /// </summary>

--- a/sdk/dotnet/Outputs/ContactPointWebhook.cs
+++ b/sdk/dotnet/Outputs/ContactPointWebhook.cs
@@ -55,6 +55,10 @@ namespace Pulumiverse.Grafana.Outputs
         /// </summary>
         public readonly string? Title;
         /// <summary>
+        /// Allows configuring TLS for the webhook notifier.
+        /// </summary>
+        public readonly ImmutableDictionary<string, string>? TlsConfig;
+        /// <summary>
         /// The UID of the contact point.
         /// </summary>
         public readonly string? Uid;
@@ -85,6 +89,8 @@ namespace Pulumiverse.Grafana.Outputs
 
             string? title,
 
+            ImmutableDictionary<string, string>? tlsConfig,
+
             string? uid,
 
             string url)
@@ -99,6 +105,7 @@ namespace Pulumiverse.Grafana.Outputs
             Message = message;
             Settings = settings;
             Title = title;
+            TlsConfig = tlsConfig;
             Uid = uid;
             Url = url;
         }

--- a/sdk/go/grafana/alerting/pulumiTypes.go
+++ b/sdk/go/grafana/alerting/pulumiTypes.go
@@ -3453,6 +3453,8 @@ type ContactPointWebhook struct {
 	Settings map[string]string `pulumi:"settings"`
 	// Templated title of the message.
 	Title *string `pulumi:"title"`
+	// Allows configuring TLS for the webhook notifier.
+	TlsConfig map[string]string `pulumi:"tlsConfig"`
 	// The UID of the contact point.
 	Uid *string `pulumi:"uid"`
 	// The URL to send webhook requests to.
@@ -3491,6 +3493,8 @@ type ContactPointWebhookArgs struct {
 	Settings pulumi.StringMapInput `pulumi:"settings"`
 	// Templated title of the message.
 	Title pulumi.StringPtrInput `pulumi:"title"`
+	// Allows configuring TLS for the webhook notifier.
+	TlsConfig pulumi.StringMapInput `pulumi:"tlsConfig"`
 	// The UID of the contact point.
 	Uid pulumi.StringPtrInput `pulumi:"uid"`
 	// The URL to send webhook requests to.
@@ -3596,6 +3600,11 @@ func (o ContactPointWebhookOutput) Settings() pulumi.StringMapOutput {
 // Templated title of the message.
 func (o ContactPointWebhookOutput) Title() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ContactPointWebhook) *string { return v.Title }).(pulumi.StringPtrOutput)
+}
+
+// Allows configuring TLS for the webhook notifier.
+func (o ContactPointWebhookOutput) TlsConfig() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ContactPointWebhook) map[string]string { return v.TlsConfig }).(pulumi.StringMapOutput)
 }
 
 // The UID of the contact point.

--- a/sdk/go/grafana/experimental/appsDashboard.go
+++ b/sdk/go/grafana/experimental/appsDashboard.go
@@ -11,7 +11,10 @@ import (
 	"github.com/pulumiverse/pulumi-grafana/sdk/go/grafana/internal"
 )
 
-// Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+// Manages Grafana dashboards using the new Grafana APIs.
+//
+// * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+// * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
 type AppsDashboard struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/grafana/experimental/appsPlaylistV0Alpha1.go
+++ b/sdk/go/grafana/experimental/appsPlaylistV0Alpha1.go
@@ -11,7 +11,10 @@ import (
 	"github.com/pulumiverse/pulumi-grafana/sdk/go/grafana/internal"
 )
 
-// Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+// Manages Grafana playlists using the new Grafana APIs.
+//
+// * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+// * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
 type AppsPlaylistV0Alpha1 struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/grafana/pulumiTypes.go
+++ b/sdk/go/grafana/pulumiTypes.go
@@ -3759,6 +3759,8 @@ type ContactPointWebhook struct {
 	Settings map[string]string `pulumi:"settings"`
 	// Templated title of the message.
 	Title *string `pulumi:"title"`
+	// Allows configuring TLS for the webhook notifier.
+	TlsConfig map[string]string `pulumi:"tlsConfig"`
 	// The UID of the contact point.
 	Uid *string `pulumi:"uid"`
 	// The URL to send webhook requests to.
@@ -3797,6 +3799,8 @@ type ContactPointWebhookArgs struct {
 	Settings pulumi.StringMapInput `pulumi:"settings"`
 	// Templated title of the message.
 	Title pulumi.StringPtrInput `pulumi:"title"`
+	// Allows configuring TLS for the webhook notifier.
+	TlsConfig pulumi.StringMapInput `pulumi:"tlsConfig"`
 	// The UID of the contact point.
 	Uid pulumi.StringPtrInput `pulumi:"uid"`
 	// The URL to send webhook requests to.
@@ -3902,6 +3906,11 @@ func (o ContactPointWebhookOutput) Settings() pulumi.StringMapOutput {
 // Templated title of the message.
 func (o ContactPointWebhookOutput) Title() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ContactPointWebhook) *string { return v.Title }).(pulumi.StringPtrOutput)
+}
+
+// Allows configuring TLS for the webhook notifier.
+func (o ContactPointWebhookOutput) TlsConfig() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ContactPointWebhook) map[string]string { return v.TlsConfig }).(pulumi.StringMapOutput)
 }
 
 // The UID of the contact point.

--- a/sdk/nodejs/experimental/appsDashboard.ts
+++ b/sdk/nodejs/experimental/appsDashboard.ts
@@ -7,7 +7,10 @@ import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
 /**
- * Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+ * Manages Grafana dashboards using the new Grafana APIs.
+ *
+ * * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+ * * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
  */
 export class AppsDashboard extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/experimental/appsPlaylistV0Alpha1.ts
+++ b/sdk/nodejs/experimental/appsPlaylistV0Alpha1.ts
@@ -7,7 +7,10 @@ import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
 /**
- * Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+ * Manages Grafana playlists using the new Grafana APIs.
+ *
+ * * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+ * * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
  */
 export class AppsPlaylistV0Alpha1 extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -867,6 +867,10 @@ export interface ContactPointWebhook {
      */
     title?: pulumi.Input<string>;
     /**
+     * Allows configuring TLS for the webhook notifier.
+     */
+    tlsConfig?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
      * The UID of the contact point.
      */
     uid?: pulumi.Input<string>;
@@ -3753,6 +3757,10 @@ export namespace alerting {
          * Templated title of the message.
          */
         title?: pulumi.Input<string>;
+        /**
+         * Allows configuring TLS for the webhook notifier.
+         */
+        tlsConfig?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
         /**
          * The UID of the contact point.
          */

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -867,6 +867,10 @@ export interface ContactPointWebhook {
      */
     title?: string;
     /**
+     * Allows configuring TLS for the webhook notifier.
+     */
+    tlsConfig?: {[key: string]: string};
+    /**
      * The UID of the contact point.
      */
     uid: string;
@@ -4080,6 +4084,10 @@ export namespace alerting {
          * Templated title of the message.
          */
         title?: string;
+        /**
+         * Allows configuring TLS for the webhook notifier.
+         */
+        tlsConfig?: {[key: string]: string};
         /**
          * The UID of the contact point.
          */

--- a/sdk/python/pulumiverse_grafana/_inputs.py
+++ b/sdk/python/pulumiverse_grafana/_inputs.py
@@ -4335,6 +4335,10 @@ if not MYPY:
         """
         Templated title of the message.
         """
+        tls_config: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]]
+        """
+        Allows configuring TLS for the webhook notifier.
+        """
         uid: NotRequired[pulumi.Input[builtins.str]]
         """
         The UID of the contact point.
@@ -4356,6 +4360,7 @@ class ContactPointWebhookArgs:
                  message: Optional[pulumi.Input[builtins.str]] = None,
                  settings: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
                  title: Optional[pulumi.Input[builtins.str]] = None,
+                 tls_config: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
                  uid: Optional[pulumi.Input[builtins.str]] = None):
         """
         :param pulumi.Input[builtins.str] url: The URL to send webhook requests to.
@@ -4369,6 +4374,7 @@ class ContactPointWebhookArgs:
         :param pulumi.Input[builtins.str] message: Custom message. You can use template variables.
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] settings: Additional custom properties to attach to the notifier. Defaults to `map[]`.
         :param pulumi.Input[builtins.str] title: Templated title of the message.
+        :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] tls_config: Allows configuring TLS for the webhook notifier.
         :param pulumi.Input[builtins.str] uid: The UID of the contact point.
         """
         pulumi.set(__self__, "url", url)
@@ -4392,6 +4398,8 @@ class ContactPointWebhookArgs:
             pulumi.set(__self__, "settings", settings)
         if title is not None:
             pulumi.set(__self__, "title", title)
+        if tls_config is not None:
+            pulumi.set(__self__, "tls_config", tls_config)
         if uid is not None:
             pulumi.set(__self__, "uid", uid)
 
@@ -4526,6 +4534,18 @@ class ContactPointWebhookArgs:
     @title.setter
     def title(self, value: Optional[pulumi.Input[builtins.str]]):
         pulumi.set(self, "title", value)
+
+    @property
+    @pulumi.getter(name="tlsConfig")
+    def tls_config(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]]:
+        """
+        Allows configuring TLS for the webhook notifier.
+        """
+        return pulumi.get(self, "tls_config")
+
+    @tls_config.setter
+    def tls_config(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]]):
+        pulumi.set(self, "tls_config", value)
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumiverse_grafana/alerting/_inputs.py
+++ b/sdk/python/pulumiverse_grafana/alerting/_inputs.py
@@ -4042,6 +4042,10 @@ if not MYPY:
         """
         Templated title of the message.
         """
+        tls_config: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]]
+        """
+        Allows configuring TLS for the webhook notifier.
+        """
         uid: NotRequired[pulumi.Input[builtins.str]]
         """
         The UID of the contact point.
@@ -4063,6 +4067,7 @@ class ContactPointWebhookArgs:
                  message: Optional[pulumi.Input[builtins.str]] = None,
                  settings: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
                  title: Optional[pulumi.Input[builtins.str]] = None,
+                 tls_config: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
                  uid: Optional[pulumi.Input[builtins.str]] = None):
         """
         :param pulumi.Input[builtins.str] url: The URL to send webhook requests to.
@@ -4076,6 +4081,7 @@ class ContactPointWebhookArgs:
         :param pulumi.Input[builtins.str] message: Custom message. You can use template variables.
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] settings: Additional custom properties to attach to the notifier. Defaults to `map[]`.
         :param pulumi.Input[builtins.str] title: Templated title of the message.
+        :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] tls_config: Allows configuring TLS for the webhook notifier.
         :param pulumi.Input[builtins.str] uid: The UID of the contact point.
         """
         pulumi.set(__self__, "url", url)
@@ -4099,6 +4105,8 @@ class ContactPointWebhookArgs:
             pulumi.set(__self__, "settings", settings)
         if title is not None:
             pulumi.set(__self__, "title", title)
+        if tls_config is not None:
+            pulumi.set(__self__, "tls_config", tls_config)
         if uid is not None:
             pulumi.set(__self__, "uid", uid)
 
@@ -4233,6 +4241,18 @@ class ContactPointWebhookArgs:
     @title.setter
     def title(self, value: Optional[pulumi.Input[builtins.str]]):
         pulumi.set(self, "title", value)
+
+    @property
+    @pulumi.getter(name="tlsConfig")
+    def tls_config(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]]:
+        """
+        Allows configuring TLS for the webhook notifier.
+        """
+        return pulumi.get(self, "tls_config")
+
+    @tls_config.setter
+    def tls_config(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]]):
+        pulumi.set(self, "tls_config", value)
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumiverse_grafana/alerting/outputs.py
+++ b/sdk/python/pulumiverse_grafana/alerting/outputs.py
@@ -2832,6 +2832,8 @@ class ContactPointWebhook(dict):
             suggest = "http_method"
         elif key == "maxAlerts":
             suggest = "max_alerts"
+        elif key == "tlsConfig":
+            suggest = "tls_config"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ContactPointWebhook. Access the value via the '{suggest}' property getter instead.")
@@ -2856,6 +2858,7 @@ class ContactPointWebhook(dict):
                  message: Optional[builtins.str] = None,
                  settings: Optional[Mapping[str, builtins.str]] = None,
                  title: Optional[builtins.str] = None,
+                 tls_config: Optional[Mapping[str, builtins.str]] = None,
                  uid: Optional[builtins.str] = None):
         """
         :param builtins.str url: The URL to send webhook requests to.
@@ -2869,6 +2872,7 @@ class ContactPointWebhook(dict):
         :param builtins.str message: Custom message. You can use template variables.
         :param Mapping[str, builtins.str] settings: Additional custom properties to attach to the notifier. Defaults to `map[]`.
         :param builtins.str title: Templated title of the message.
+        :param Mapping[str, builtins.str] tls_config: Allows configuring TLS for the webhook notifier.
         :param builtins.str uid: The UID of the contact point.
         """
         pulumi.set(__self__, "url", url)
@@ -2892,6 +2896,8 @@ class ContactPointWebhook(dict):
             pulumi.set(__self__, "settings", settings)
         if title is not None:
             pulumi.set(__self__, "title", title)
+        if tls_config is not None:
+            pulumi.set(__self__, "tls_config", tls_config)
         if uid is not None:
             pulumi.set(__self__, "uid", uid)
 
@@ -2982,6 +2988,14 @@ class ContactPointWebhook(dict):
         Templated title of the message.
         """
         return pulumi.get(self, "title")
+
+    @property
+    @pulumi.getter(name="tlsConfig")
+    def tls_config(self) -> Optional[Mapping[str, builtins.str]]:
+        """
+        Allows configuring TLS for the webhook notifier.
+        """
+        return pulumi.get(self, "tls_config")
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumiverse_grafana/experimental/apps_dashboard.py
+++ b/sdk/python/pulumiverse_grafana/experimental/apps_dashboard.py
@@ -142,7 +142,10 @@ class AppsDashboard(pulumi.CustomResource):
                  spec: Optional[pulumi.Input[Union['AppsDashboardSpecArgs', 'AppsDashboardSpecArgsDict']]] = None,
                  __props__=None):
         """
-        Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+        Manages Grafana dashboards using the new Grafana APIs.
+
+        * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+        * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -157,7 +160,10 @@ class AppsDashboard(pulumi.CustomResource):
                  args: Optional[AppsDashboardArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+        Manages Grafana dashboards using the new Grafana APIs.
+
+        * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+        * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
 
         :param str resource_name: The name of the resource.
         :param AppsDashboardArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumiverse_grafana/experimental/apps_playlist_v0_alpha1.py
+++ b/sdk/python/pulumiverse_grafana/experimental/apps_playlist_v0_alpha1.py
@@ -142,7 +142,10 @@ class AppsPlaylistV0Alpha1(pulumi.CustomResource):
                  spec: Optional[pulumi.Input[Union['AppsPlaylistV0Alpha1SpecArgs', 'AppsPlaylistV0Alpha1SpecArgsDict']]] = None,
                  __props__=None):
         """
-        Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+        Manages Grafana playlists using the new Grafana APIs.
+
+        * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+        * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -157,7 +160,10 @@ class AppsPlaylistV0Alpha1(pulumi.CustomResource):
                  args: Optional[AppsPlaylistV0Alpha1Args] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+        Manages Grafana playlists using the new Grafana APIs.
+
+        * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+        * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
 
         :param str resource_name: The name of the resource.
         :param AppsPlaylistV0Alpha1Args args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumiverse_grafana/outputs.py
+++ b/sdk/python/pulumiverse_grafana/outputs.py
@@ -3048,6 +3048,8 @@ class ContactPointWebhook(dict):
             suggest = "http_method"
         elif key == "maxAlerts":
             suggest = "max_alerts"
+        elif key == "tlsConfig":
+            suggest = "tls_config"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ContactPointWebhook. Access the value via the '{suggest}' property getter instead.")
@@ -3072,6 +3074,7 @@ class ContactPointWebhook(dict):
                  message: Optional[builtins.str] = None,
                  settings: Optional[Mapping[str, builtins.str]] = None,
                  title: Optional[builtins.str] = None,
+                 tls_config: Optional[Mapping[str, builtins.str]] = None,
                  uid: Optional[builtins.str] = None):
         """
         :param builtins.str url: The URL to send webhook requests to.
@@ -3085,6 +3088,7 @@ class ContactPointWebhook(dict):
         :param builtins.str message: Custom message. You can use template variables.
         :param Mapping[str, builtins.str] settings: Additional custom properties to attach to the notifier. Defaults to `map[]`.
         :param builtins.str title: Templated title of the message.
+        :param Mapping[str, builtins.str] tls_config: Allows configuring TLS for the webhook notifier.
         :param builtins.str uid: The UID of the contact point.
         """
         pulumi.set(__self__, "url", url)
@@ -3108,6 +3112,8 @@ class ContactPointWebhook(dict):
             pulumi.set(__self__, "settings", settings)
         if title is not None:
             pulumi.set(__self__, "title", title)
+        if tls_config is not None:
+            pulumi.set(__self__, "tls_config", tls_config)
         if uid is not None:
             pulumi.set(__self__, "uid", uid)
 
@@ -3198,6 +3204,14 @@ class ContactPointWebhook(dict):
         Templated title of the message.
         """
         return pulumi.get(self, "title")
+
+    @property
+    @pulumi.getter(name="tlsConfig")
+    def tls_config(self) -> Optional[Mapping[str, builtins.str]]:
+        """
+        Allows configuring TLS for the webhook notifier.
+        """
+        return pulumi.get(self, "tls_config")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-grafana --target-version v3.23.0`.

---

- Upgrading terraform-provider-grafana from 3.22.4  to 3.23.0.
