### PR TITLE
Upgrade terraform-provider-grafana to v3.25.8

### DIFF
--- a/provider/cmd/pulumi-resource-grafana/schema.json
+++ b/provider/cmd/pulumi-resource-grafana/schema.json
@@ -13632,6 +13632,14 @@
                     "type": "string",
                     "description": "Name of the Fleet Management instance configured for this stack.\n"
                 },
+                "fleetManagementPrivateConnectivityInfoPrivateDns": {
+                    "type": "string",
+                    "description": "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
+                },
+                "fleetManagementPrivateConnectivityInfoServiceName": {
+                    "type": "string",
+                    "description": "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
+                },
                 "fleetManagementStatus": {
                     "type": "string",
                     "description": "Status of the Fleet Management instance configured for this stack.\n"
@@ -13873,6 +13881,8 @@
                 "alertmanagerUserId",
                 "clusterSlug",
                 "fleetManagementName",
+                "fleetManagementPrivateConnectivityInfoPrivateDns",
+                "fleetManagementPrivateConnectivityInfoServiceName",
                 "fleetManagementStatus",
                 "fleetManagementUrl",
                 "fleetManagementUserId",
@@ -14005,6 +14015,14 @@
                     "fleetManagementName": {
                         "type": "string",
                         "description": "Name of the Fleet Management instance configured for this stack.\n"
+                    },
+                    "fleetManagementPrivateConnectivityInfoPrivateDns": {
+                        "type": "string",
+                        "description": "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
+                    },
+                    "fleetManagementPrivateConnectivityInfoServiceName": {
+                        "type": "string",
+                        "description": "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
                     },
                     "fleetManagementStatus": {
                         "type": "string",
@@ -15920,8 +15938,12 @@
             ]
         },
         "grafana:enterprise/scimConfig:ScimConfig": {
-            "description": "**Note:** This resource is available only with Grafana Enterprise.\n\n* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)\n\n## Import\n\n```sh\n$ pulumi import grafana:enterprise/scimConfig:ScimConfig name \"\"\n```\n\n```sh\n$ pulumi import grafana:enterprise/scimConfig:ScimConfig name \"{{ orgID }}\"\n```\n\n",
+            "description": "**Note:** This resource is available only with Grafana Enterprise.\n\n* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)\n\n## Example Usage\n\n\u003c!--Start PulumiCodeChooser --\u003e\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as grafana from \"@pulumiverse/grafana\";\n\nconst _default = new grafana.enterprise.ScimConfig(\"default\", {\n    enableUserSync: true,\n    enableGroupSync: false,\n    allowNonProvisionedUsers: false,\n});\n```\n```python\nimport pulumi\nimport pulumiverse_grafana as grafana\n\ndefault = grafana.enterprise.ScimConfig(\"default\",\n    enable_user_sync=True,\n    enable_group_sync=False,\n    allow_non_provisioned_users=False)\n```\n```csharp\nusing System.Collections.Generic;\nusing System.Linq;\nusing Pulumi;\nusing Grafana = Pulumiverse.Grafana;\n\nreturn await Deployment.RunAsync(() =\u003e \n{\n    var @default = new Grafana.Enterprise.ScimConfig(\"default\", new()\n    {\n        EnableUserSync = true,\n        EnableGroupSync = false,\n        AllowNonProvisionedUsers = false,\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n\t\"github.com/pulumiverse/pulumi-grafana/sdk/go/grafana/enterprise\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\t_, err := enterprise.NewScimConfig(ctx, \"default\", \u0026enterprise.ScimConfigArgs{\n\t\t\tEnableUserSync:           pulumi.Bool(true),\n\t\t\tEnableGroupSync:          pulumi.Bool(false),\n\t\t\tAllowNonProvisionedUsers: pulumi.Bool(false),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.grafana.enterprise.ScimConfig;\nimport com.pulumi.grafana.enterprise.ScimConfigArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var default_ = new ScimConfig(\"default\", ScimConfigArgs.builder()\n            .enableUserSync(true)\n            .enableGroupSync(false)\n            .allowNonProvisionedUsers(false)\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  default:\n    type: grafana:enterprise:ScimConfig\n    properties:\n      enableUserSync: true\n      enableGroupSync: false\n      allowNonProvisionedUsers: false\n```\n\u003c!--End PulumiCodeChooser --\u003e\n\n## Import\n\n```sh\n$ pulumi import grafana:enterprise/scimConfig:ScimConfig name \"\"\n```\n\n```sh\n$ pulumi import grafana:enterprise/scimConfig:ScimConfig name \"{{ orgID }}\"\n```\n\n",
             "properties": {
+                "allowNonProvisionedUsers": {
+                    "type": "boolean",
+                    "description": "Whether to allow non-provisioned users to access Grafana.\n"
+                },
                 "enableGroupSync": {
                     "type": "boolean",
                     "description": "Whether group synchronization is enabled.\n"
@@ -15936,10 +15958,15 @@
                 }
             },
             "required": [
+                "allowNonProvisionedUsers",
                 "enableGroupSync",
                 "enableUserSync"
             ],
             "inputProperties": {
+                "allowNonProvisionedUsers": {
+                    "type": "boolean",
+                    "description": "Whether to allow non-provisioned users to access Grafana.\n"
+                },
                 "enableGroupSync": {
                     "type": "boolean",
                     "description": "Whether group synchronization is enabled.\n"
@@ -15955,12 +15982,17 @@
                 }
             },
             "requiredInputs": [
+                "allowNonProvisionedUsers",
                 "enableGroupSync",
                 "enableUserSync"
             ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering ScimConfig resources.\n",
                 "properties": {
+                    "allowNonProvisionedUsers": {
+                        "type": "boolean",
+                        "description": "Whether to allow non-provisioned users to access Grafana.\n"
+                    },
                     "enableGroupSync": {
                         "type": "boolean",
                         "description": "Whether group synchronization is enabled.\n"
@@ -16142,7 +16174,7 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "Whether the collector is enabled or not\n"
+                    "description": "Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service\n"
                 },
                 "remoteAttributes": {
                     "type": "object",
@@ -16159,7 +16191,7 @@
             "inputProperties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "Whether the collector is enabled or not\n"
+                    "description": "Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service\n"
                 },
                 "remoteAttributes": {
                     "type": "object",
@@ -16174,7 +16206,7 @@
                 "properties": {
                     "enabled": {
                         "type": "boolean",
-                        "description": "Whether the collector is enabled or not\n"
+                        "description": "Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service\n"
                     },
                     "remoteAttributes": {
                         "type": "object",
@@ -16952,6 +16984,14 @@
                     "type": "string",
                     "description": "Name of the Fleet Management instance configured for this stack.\n"
                 },
+                "fleetManagementPrivateConnectivityInfoPrivateDns": {
+                    "type": "string",
+                    "description": "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
+                },
+                "fleetManagementPrivateConnectivityInfoServiceName": {
+                    "type": "string",
+                    "description": "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
+                },
                 "fleetManagementStatus": {
                     "type": "string",
                     "description": "Status of the Fleet Management instance configured for this stack.\n"
@@ -17193,6 +17233,8 @@
                 "alertmanagerUserId",
                 "clusterSlug",
                 "fleetManagementName",
+                "fleetManagementPrivateConnectivityInfoPrivateDns",
+                "fleetManagementPrivateConnectivityInfoServiceName",
                 "fleetManagementStatus",
                 "fleetManagementUrl",
                 "fleetManagementUserId",
@@ -17325,6 +17367,14 @@
                     "fleetManagementName": {
                         "type": "string",
                         "description": "Name of the Fleet Management instance configured for this stack.\n"
+                    },
+                    "fleetManagementPrivateConnectivityInfoPrivateDns": {
+                        "type": "string",
+                        "description": "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
+                    },
+                    "fleetManagementPrivateConnectivityInfoServiceName": {
+                        "type": "string",
+                        "description": "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n"
                     },
                     "fleetManagementStatus": {
                         "type": "string",
@@ -29598,6 +29648,14 @@
                         "description": "Name of the Fleet Management instance configured for this stack.\n",
                         "type": "string"
                     },
+                    "fleetManagementPrivateConnectivityInfoPrivateDns": {
+                        "description": "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n",
+                        "type": "string"
+                    },
+                    "fleetManagementPrivateConnectivityInfoServiceName": {
+                        "description": "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n",
+                        "type": "string"
+                    },
                     "fleetManagementStatus": {
                         "description": "Status of the Fleet Management instance configured for this stack.\n",
                         "type": "string"
@@ -29836,6 +29894,8 @@
                     "clusterSlug",
                     "description",
                     "fleetManagementName",
+                    "fleetManagementPrivateConnectivityInfoPrivateDns",
+                    "fleetManagementPrivateConnectivityInfoServiceName",
                     "fleetManagementStatus",
                     "fleetManagementUrl",
                     "fleetManagementUserId",
@@ -30392,7 +30452,7 @@
                 "description": "A collection of values returned by getCollector.\n",
                 "properties": {
                     "enabled": {
-                        "description": "Whether the collector is enabled or not\n",
+                        "description": "Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service\n",
                         "type": "boolean"
                     },
                     "id": {
@@ -30673,6 +30733,14 @@
                         "description": "Name of the Fleet Management instance configured for this stack.\n",
                         "type": "string"
                     },
+                    "fleetManagementPrivateConnectivityInfoPrivateDns": {
+                        "description": "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n",
+                        "type": "string"
+                    },
+                    "fleetManagementPrivateConnectivityInfoServiceName": {
+                        "description": "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)\n",
+                        "type": "string"
+                    },
                     "fleetManagementStatus": {
                         "description": "Status of the Fleet Management instance configured for this stack.\n",
                         "type": "string"
@@ -30911,6 +30979,8 @@
                     "clusterSlug",
                     "description",
                     "fleetManagementName",
+                    "fleetManagementPrivateConnectivityInfoPrivateDns",
+                    "fleetManagementPrivateConnectivityInfoServiceName",
                     "fleetManagementStatus",
                     "fleetManagementUrl",
                     "fleetManagementUserId",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/grafana/terraform-provider-grafana/v3 v3.25.7
+	github.com/grafana/terraform-provider-grafana/v3 v3.25.8
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.110.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1954,8 +1954,8 @@ github.com/grafana/synthetic-monitoring-agent v0.34.4 h1:2wlf6qJifAMIfc3JnmPamGc
 github.com/grafana/synthetic-monitoring-agent v0.34.4/go.mod h1:V/Wj1omTCRzsK++f9UZ7QK/neZXpP1ESOFkWJ62g5ik=
 github.com/grafana/synthetic-monitoring-api-go-client v0.14.0 h1:XBqG4F5SON1Bz6DwnK4xw2bPny3Y8iv+DF/RYAhL+zQ=
 github.com/grafana/synthetic-monitoring-api-go-client v0.14.0/go.mod h1:+58mGFzv0T/wcBCHPK1NpKpGtsYkeSKRBLH5M89hgBE=
-github.com/grafana/terraform-provider-grafana/v3 v3.25.7 h1:s/Z7TDVZQiZplVq7lrc+FQJp3QCiNYBgtFiGdU+FzcI=
-github.com/grafana/terraform-provider-grafana/v3 v3.25.7/go.mod h1:zL5rUyvNe4XlFkh9fmfAvpBPt8Ii5tHMHBofkZCV5WE=
+github.com/grafana/terraform-provider-grafana/v3 v3.25.8 h1:EK6n81sc9IDDEatstUJrbavJDR4SiUY8CErdr0pV2DE=
+github.com/grafana/terraform-provider-grafana/v3 v3.25.8/go.mod h1:zL5rUyvNe4XlFkh9fmfAvpBPt8Ii5tHMHBofkZCV5WE=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdixfIJjVzuUJdnv+5xsPutog=

--- a/sdk/dotnet/Cloud/GetStack.cs
+++ b/sdk/dotnet/Cloud/GetStack.cs
@@ -180,6 +180,14 @@ namespace Pulumiverse.Grafana.Cloud
         /// </summary>
         public readonly string FleetManagementName;
         /// <summary>
+        /// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        public readonly string FleetManagementPrivateConnectivityInfoPrivateDns;
+        /// <summary>
+        /// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        public readonly string FleetManagementPrivateConnectivityInfoServiceName;
+        /// <summary>
         /// Status of the Fleet Management instance configured for this stack.
         /// </summary>
         public readonly string FleetManagementStatus;
@@ -394,6 +402,10 @@ namespace Pulumiverse.Grafana.Cloud
 
             string fleetManagementName,
 
+            string fleetManagementPrivateConnectivityInfoPrivateDns,
+
+            string fleetManagementPrivateConnectivityInfoServiceName,
+
             string fleetManagementStatus,
 
             string fleetManagementUrl,
@@ -522,6 +534,8 @@ namespace Pulumiverse.Grafana.Cloud
             ClusterSlug = clusterSlug;
             Description = description;
             FleetManagementName = fleetManagementName;
+            FleetManagementPrivateConnectivityInfoPrivateDns = fleetManagementPrivateConnectivityInfoPrivateDns;
+            FleetManagementPrivateConnectivityInfoServiceName = fleetManagementPrivateConnectivityInfoServiceName;
             FleetManagementStatus = fleetManagementStatus;
             FleetManagementUrl = fleetManagementUrl;
             FleetManagementUserId = fleetManagementUserId;

--- a/sdk/dotnet/Cloud/Stack.cs
+++ b/sdk/dotnet/Cloud/Stack.cs
@@ -98,6 +98,18 @@ namespace Pulumiverse.Grafana.Cloud
         public Output<string> FleetManagementName { get; private set; } = null!;
 
         /// <summary>
+        /// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Output("fleetManagementPrivateConnectivityInfoPrivateDns")]
+        public Output<string> FleetManagementPrivateConnectivityInfoPrivateDns { get; private set; } = null!;
+
+        /// <summary>
+        /// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Output("fleetManagementPrivateConnectivityInfoServiceName")]
+        public Output<string> FleetManagementPrivateConnectivityInfoServiceName { get; private set; } = null!;
+
+        /// <summary>
         /// Status of the Fleet Management instance configured for this stack.
         /// </summary>
         [Output("fleetManagementStatus")]
@@ -578,6 +590,18 @@ namespace Pulumiverse.Grafana.Cloud
         /// </summary>
         [Input("fleetManagementName")]
         public Input<string>? FleetManagementName { get; set; }
+
+        /// <summary>
+        /// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Input("fleetManagementPrivateConnectivityInfoPrivateDns")]
+        public Input<string>? FleetManagementPrivateConnectivityInfoPrivateDns { get; set; }
+
+        /// <summary>
+        /// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Input("fleetManagementPrivateConnectivityInfoServiceName")]
+        public Input<string>? FleetManagementPrivateConnectivityInfoServiceName { get; set; }
 
         /// <summary>
         /// Status of the Fleet Management instance configured for this stack.

--- a/sdk/dotnet/CloudStack.cs
+++ b/sdk/dotnet/CloudStack.cs
@@ -99,6 +99,18 @@ namespace Pulumiverse.Grafana
         public Output<string> FleetManagementName { get; private set; } = null!;
 
         /// <summary>
+        /// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Output("fleetManagementPrivateConnectivityInfoPrivateDns")]
+        public Output<string> FleetManagementPrivateConnectivityInfoPrivateDns { get; private set; } = null!;
+
+        /// <summary>
+        /// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Output("fleetManagementPrivateConnectivityInfoServiceName")]
+        public Output<string> FleetManagementPrivateConnectivityInfoServiceName { get; private set; } = null!;
+
+        /// <summary>
         /// Status of the Fleet Management instance configured for this stack.
         /// </summary>
         [Output("fleetManagementStatus")]
@@ -575,6 +587,18 @@ namespace Pulumiverse.Grafana
         /// </summary>
         [Input("fleetManagementName")]
         public Input<string>? FleetManagementName { get; set; }
+
+        /// <summary>
+        /// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Input("fleetManagementPrivateConnectivityInfoPrivateDns")]
+        public Input<string>? FleetManagementPrivateConnectivityInfoPrivateDns { get; set; }
+
+        /// <summary>
+        /// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        [Input("fleetManagementPrivateConnectivityInfoServiceName")]
+        public Input<string>? FleetManagementPrivateConnectivityInfoServiceName { get; set; }
 
         /// <summary>
         /// Status of the Fleet Management instance configured for this stack.

--- a/sdk/dotnet/Enterprise/ScimConfig.cs
+++ b/sdk/dotnet/Enterprise/ScimConfig.cs
@@ -15,6 +15,26 @@ namespace Pulumiverse.Grafana.Enterprise
     /// 
     /// * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)
     /// 
+    /// ## Example Usage
+    /// 
+    /// ```csharp
+    /// using System.Collections.Generic;
+    /// using System.Linq;
+    /// using Pulumi;
+    /// using Grafana = Pulumiverse.Grafana;
+    /// 
+    /// return await Deployment.RunAsync(() =&gt; 
+    /// {
+    ///     var @default = new Grafana.Enterprise.ScimConfig("default", new()
+    ///     {
+    ///         EnableUserSync = true,
+    ///         EnableGroupSync = false,
+    ///         AllowNonProvisionedUsers = false,
+    ///     });
+    /// 
+    /// });
+    /// ```
+    /// 
     /// ## Import
     /// 
     /// ```sh
@@ -28,6 +48,12 @@ namespace Pulumiverse.Grafana.Enterprise
     [GrafanaResourceType("grafana:enterprise/scimConfig:ScimConfig")]
     public partial class ScimConfig : global::Pulumi.CustomResource
     {
+        /// <summary>
+        /// Whether to allow non-provisioned users to access Grafana.
+        /// </summary>
+        [Output("allowNonProvisionedUsers")]
+        public Output<bool> AllowNonProvisionedUsers { get; private set; } = null!;
+
         /// <summary>
         /// Whether group synchronization is enabled.
         /// </summary>
@@ -94,6 +120,12 @@ namespace Pulumiverse.Grafana.Enterprise
     public sealed class ScimConfigArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// Whether to allow non-provisioned users to access Grafana.
+        /// </summary>
+        [Input("allowNonProvisionedUsers", required: true)]
+        public Input<bool> AllowNonProvisionedUsers { get; set; } = null!;
+
+        /// <summary>
         /// Whether group synchronization is enabled.
         /// </summary>
         [Input("enableGroupSync", required: true)]
@@ -119,6 +151,12 @@ namespace Pulumiverse.Grafana.Enterprise
 
     public sealed class ScimConfigState : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Whether to allow non-provisioned users to access Grafana.
+        /// </summary>
+        [Input("allowNonProvisionedUsers")]
+        public Input<bool>? AllowNonProvisionedUsers { get; set; }
+
         /// <summary>
         /// Whether group synchronization is enabled.
         /// </summary>

--- a/sdk/dotnet/FleetManagement/Collector.cs
+++ b/sdk/dotnet/FleetManagement/Collector.cs
@@ -31,7 +31,7 @@ namespace Pulumiverse.Grafana.FleetManagement
     public partial class Collector : global::Pulumi.CustomResource
     {
         /// <summary>
-        /// Whether the collector is enabled or not
+        /// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         /// </summary>
         [Output("enabled")]
         public Output<bool> Enabled { get; private set; } = null!;
@@ -90,7 +90,7 @@ namespace Pulumiverse.Grafana.FleetManagement
     public sealed class CollectorArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether the collector is enabled or not
+        /// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }
@@ -116,7 +116,7 @@ namespace Pulumiverse.Grafana.FleetManagement
     public sealed class CollectorState : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Whether the collector is enabled or not
+        /// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         /// </summary>
         [Input("enabled")]
         public Input<bool>? Enabled { get; set; }

--- a/sdk/dotnet/FleetManagement/GetCollector.cs
+++ b/sdk/dotnet/FleetManagement/GetCollector.cs
@@ -140,7 +140,7 @@ namespace Pulumiverse.Grafana.FleetManagement
     public sealed class GetCollectorResult
     {
         /// <summary>
-        /// Whether the collector is enabled or not
+        /// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         /// </summary>
         public readonly bool Enabled;
         /// <summary>

--- a/sdk/dotnet/GetCloudStack.cs
+++ b/sdk/dotnet/GetCloudStack.cs
@@ -181,6 +181,14 @@ namespace Pulumiverse.Grafana
         /// </summary>
         public readonly string FleetManagementName;
         /// <summary>
+        /// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        public readonly string FleetManagementPrivateConnectivityInfoPrivateDns;
+        /// <summary>
+        /// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        /// </summary>
+        public readonly string FleetManagementPrivateConnectivityInfoServiceName;
+        /// <summary>
         /// Status of the Fleet Management instance configured for this stack.
         /// </summary>
         public readonly string FleetManagementStatus;
@@ -395,6 +403,10 @@ namespace Pulumiverse.Grafana
 
             string fleetManagementName,
 
+            string fleetManagementPrivateConnectivityInfoPrivateDns,
+
+            string fleetManagementPrivateConnectivityInfoServiceName,
+
             string fleetManagementStatus,
 
             string fleetManagementUrl,
@@ -523,6 +535,8 @@ namespace Pulumiverse.Grafana
             ClusterSlug = clusterSlug;
             Description = description;
             FleetManagementName = fleetManagementName;
+            FleetManagementPrivateConnectivityInfoPrivateDns = fleetManagementPrivateConnectivityInfoPrivateDns;
+            FleetManagementPrivateConnectivityInfoServiceName = fleetManagementPrivateConnectivityInfoServiceName;
             FleetManagementStatus = fleetManagementStatus;
             FleetManagementUrl = fleetManagementUrl;
             FleetManagementUserId = fleetManagementUserId;

--- a/sdk/go/grafana/cloud/getStack.go
+++ b/sdk/go/grafana/cloud/getStack.go
@@ -79,6 +79,10 @@ type LookupStackResult struct {
 	Description string `pulumi:"description"`
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName string `pulumi:"fleetManagementName"`
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns string `pulumi:"fleetManagementPrivateConnectivityInfoPrivateDns"`
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName string `pulumi:"fleetManagementPrivateConnectivityInfoServiceName"`
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus string `pulumi:"fleetManagementStatus"`
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -260,6 +264,16 @@ func (o LookupStackResultOutput) Description() pulumi.StringOutput {
 // Name of the Fleet Management instance configured for this stack.
 func (o LookupStackResultOutput) FleetManagementName() pulumi.StringOutput {
 	return o.ApplyT(func(v LookupStackResult) string { return v.FleetManagementName }).(pulumi.StringOutput)
+}
+
+// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o LookupStackResultOutput) FleetManagementPrivateConnectivityInfoPrivateDns() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupStackResult) string { return v.FleetManagementPrivateConnectivityInfoPrivateDns }).(pulumi.StringOutput)
+}
+
+// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o LookupStackResultOutput) FleetManagementPrivateConnectivityInfoServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupStackResult) string { return v.FleetManagementPrivateConnectivityInfoServiceName }).(pulumi.StringOutput)
 }
 
 // Status of the Fleet Management instance configured for this stack.

--- a/sdk/go/grafana/cloud/stack.go
+++ b/sdk/go/grafana/cloud/stack.go
@@ -73,6 +73,10 @@ type Stack struct {
 	Description pulumi.StringPtrOutput `pulumi:"description"`
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName pulumi.StringOutput `pulumi:"fleetManagementName"`
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns pulumi.StringOutput `pulumi:"fleetManagementPrivateConnectivityInfoPrivateDns"`
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName pulumi.StringOutput `pulumi:"fleetManagementPrivateConnectivityInfoServiceName"`
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus pulumi.StringOutput `pulumi:"fleetManagementStatus"`
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -237,6 +241,10 @@ type stackState struct {
 	Description *string `pulumi:"description"`
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName *string `pulumi:"fleetManagementName"`
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns *string `pulumi:"fleetManagementPrivateConnectivityInfoPrivateDns"`
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName *string `pulumi:"fleetManagementPrivateConnectivityInfoServiceName"`
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus *string `pulumi:"fleetManagementStatus"`
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -363,6 +371,10 @@ type StackState struct {
 	Description pulumi.StringPtrInput
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName pulumi.StringPtrInput
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns pulumi.StringPtrInput
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName pulumi.StringPtrInput
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus pulumi.StringPtrInput
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -640,6 +652,16 @@ func (o StackOutput) Description() pulumi.StringPtrOutput {
 // Name of the Fleet Management instance configured for this stack.
 func (o StackOutput) FleetManagementName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Stack) pulumi.StringOutput { return v.FleetManagementName }).(pulumi.StringOutput)
+}
+
+// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o StackOutput) FleetManagementPrivateConnectivityInfoPrivateDns() pulumi.StringOutput {
+	return o.ApplyT(func(v *Stack) pulumi.StringOutput { return v.FleetManagementPrivateConnectivityInfoPrivateDns }).(pulumi.StringOutput)
+}
+
+// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o StackOutput) FleetManagementPrivateConnectivityInfoServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Stack) pulumi.StringOutput { return v.FleetManagementPrivateConnectivityInfoServiceName }).(pulumi.StringOutput)
 }
 
 // Status of the Fleet Management instance configured for this stack.

--- a/sdk/go/grafana/cloudStack.go
+++ b/sdk/go/grafana/cloudStack.go
@@ -75,6 +75,10 @@ type CloudStack struct {
 	Description pulumi.StringPtrOutput `pulumi:"description"`
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName pulumi.StringOutput `pulumi:"fleetManagementName"`
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns pulumi.StringOutput `pulumi:"fleetManagementPrivateConnectivityInfoPrivateDns"`
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName pulumi.StringOutput `pulumi:"fleetManagementPrivateConnectivityInfoServiceName"`
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus pulumi.StringOutput `pulumi:"fleetManagementStatus"`
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -233,6 +237,10 @@ type cloudStackState struct {
 	Description *string `pulumi:"description"`
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName *string `pulumi:"fleetManagementName"`
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns *string `pulumi:"fleetManagementPrivateConnectivityInfoPrivateDns"`
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName *string `pulumi:"fleetManagementPrivateConnectivityInfoServiceName"`
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus *string `pulumi:"fleetManagementStatus"`
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -359,6 +367,10 @@ type CloudStackState struct {
 	Description pulumi.StringPtrInput
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName pulumi.StringPtrInput
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns pulumi.StringPtrInput
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName pulumi.StringPtrInput
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus pulumi.StringPtrInput
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -636,6 +648,16 @@ func (o CloudStackOutput) Description() pulumi.StringPtrOutput {
 // Name of the Fleet Management instance configured for this stack.
 func (o CloudStackOutput) FleetManagementName() pulumi.StringOutput {
 	return o.ApplyT(func(v *CloudStack) pulumi.StringOutput { return v.FleetManagementName }).(pulumi.StringOutput)
+}
+
+// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o CloudStackOutput) FleetManagementPrivateConnectivityInfoPrivateDns() pulumi.StringOutput {
+	return o.ApplyT(func(v *CloudStack) pulumi.StringOutput { return v.FleetManagementPrivateConnectivityInfoPrivateDns }).(pulumi.StringOutput)
+}
+
+// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o CloudStackOutput) FleetManagementPrivateConnectivityInfoServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v *CloudStack) pulumi.StringOutput { return v.FleetManagementPrivateConnectivityInfoServiceName }).(pulumi.StringOutput)
 }
 
 // Status of the Fleet Management instance configured for this stack.

--- a/sdk/go/grafana/enterprise/scimConfig.go
+++ b/sdk/go/grafana/enterprise/scimConfig.go
@@ -16,6 +16,34 @@ import (
 //
 // * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)
 //
+// ## Example Usage
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//	"github.com/pulumiverse/pulumi-grafana/sdk/go/grafana/enterprise"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := enterprise.NewScimConfig(ctx, "default", &enterprise.ScimConfigArgs{
+//				EnableUserSync:           pulumi.Bool(true),
+//				EnableGroupSync:          pulumi.Bool(false),
+//				AllowNonProvisionedUsers: pulumi.Bool(false),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
 // ## Import
 //
 // ```sh
@@ -28,6 +56,8 @@ import (
 type ScimConfig struct {
 	pulumi.CustomResourceState
 
+	// Whether to allow non-provisioned users to access Grafana.
+	AllowNonProvisionedUsers pulumi.BoolOutput `pulumi:"allowNonProvisionedUsers"`
 	// Whether group synchronization is enabled.
 	EnableGroupSync pulumi.BoolOutput `pulumi:"enableGroupSync"`
 	// Whether user synchronization is enabled.
@@ -43,6 +73,9 @@ func NewScimConfig(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.AllowNonProvisionedUsers == nil {
+		return nil, errors.New("invalid value for required argument 'AllowNonProvisionedUsers'")
+	}
 	if args.EnableGroupSync == nil {
 		return nil, errors.New("invalid value for required argument 'EnableGroupSync'")
 	}
@@ -72,6 +105,8 @@ func GetScimConfig(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering ScimConfig resources.
 type scimConfigState struct {
+	// Whether to allow non-provisioned users to access Grafana.
+	AllowNonProvisionedUsers *bool `pulumi:"allowNonProvisionedUsers"`
 	// Whether group synchronization is enabled.
 	EnableGroupSync *bool `pulumi:"enableGroupSync"`
 	// Whether user synchronization is enabled.
@@ -81,6 +116,8 @@ type scimConfigState struct {
 }
 
 type ScimConfigState struct {
+	// Whether to allow non-provisioned users to access Grafana.
+	AllowNonProvisionedUsers pulumi.BoolPtrInput
 	// Whether group synchronization is enabled.
 	EnableGroupSync pulumi.BoolPtrInput
 	// Whether user synchronization is enabled.
@@ -94,6 +131,8 @@ func (ScimConfigState) ElementType() reflect.Type {
 }
 
 type scimConfigArgs struct {
+	// Whether to allow non-provisioned users to access Grafana.
+	AllowNonProvisionedUsers bool `pulumi:"allowNonProvisionedUsers"`
 	// Whether group synchronization is enabled.
 	EnableGroupSync bool `pulumi:"enableGroupSync"`
 	// Whether user synchronization is enabled.
@@ -104,6 +143,8 @@ type scimConfigArgs struct {
 
 // The set of arguments for constructing a ScimConfig resource.
 type ScimConfigArgs struct {
+	// Whether to allow non-provisioned users to access Grafana.
+	AllowNonProvisionedUsers pulumi.BoolInput
 	// Whether group synchronization is enabled.
 	EnableGroupSync pulumi.BoolInput
 	// Whether user synchronization is enabled.
@@ -197,6 +238,11 @@ func (o ScimConfigOutput) ToScimConfigOutput() ScimConfigOutput {
 
 func (o ScimConfigOutput) ToScimConfigOutputWithContext(ctx context.Context) ScimConfigOutput {
 	return o
+}
+
+// Whether to allow non-provisioned users to access Grafana.
+func (o ScimConfigOutput) AllowNonProvisionedUsers() pulumi.BoolOutput {
+	return o.ApplyT(func(v *ScimConfig) pulumi.BoolOutput { return v.AllowNonProvisionedUsers }).(pulumi.BoolOutput)
 }
 
 // Whether group synchronization is enabled.

--- a/sdk/go/grafana/fleetmanagement/collector.go
+++ b/sdk/go/grafana/fleetmanagement/collector.go
@@ -29,7 +29,7 @@ import (
 type Collector struct {
 	pulumi.CustomResourceState
 
-	// Whether the collector is enabled or not
+	// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 	Enabled pulumi.BoolOutput `pulumi:"enabled"`
 	// Remote attributes for the collector
 	RemoteAttributes pulumi.StringMapOutput `pulumi:"remoteAttributes"`
@@ -65,14 +65,14 @@ func GetCollector(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering Collector resources.
 type collectorState struct {
-	// Whether the collector is enabled or not
+	// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 	Enabled *bool `pulumi:"enabled"`
 	// Remote attributes for the collector
 	RemoteAttributes map[string]string `pulumi:"remoteAttributes"`
 }
 
 type CollectorState struct {
-	// Whether the collector is enabled or not
+	// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 	Enabled pulumi.BoolPtrInput
 	// Remote attributes for the collector
 	RemoteAttributes pulumi.StringMapInput
@@ -83,7 +83,7 @@ func (CollectorState) ElementType() reflect.Type {
 }
 
 type collectorArgs struct {
-	// Whether the collector is enabled or not
+	// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 	Enabled *bool `pulumi:"enabled"`
 	// Remote attributes for the collector
 	RemoteAttributes map[string]string `pulumi:"remoteAttributes"`
@@ -91,7 +91,7 @@ type collectorArgs struct {
 
 // The set of arguments for constructing a Collector resource.
 type CollectorArgs struct {
-	// Whether the collector is enabled or not
+	// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 	Enabled pulumi.BoolPtrInput
 	// Remote attributes for the collector
 	RemoteAttributes pulumi.StringMapInput
@@ -184,7 +184,7 @@ func (o CollectorOutput) ToCollectorOutputWithContext(ctx context.Context) Colle
 	return o
 }
 
-// Whether the collector is enabled or not
+// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 func (o CollectorOutput) Enabled() pulumi.BoolOutput {
 	return o.ApplyT(func(v *Collector) pulumi.BoolOutput { return v.Enabled }).(pulumi.BoolOutput)
 }

--- a/sdk/go/grafana/fleetmanagement/getCollector.go
+++ b/sdk/go/grafana/fleetmanagement/getCollector.go
@@ -63,7 +63,7 @@ type LookupCollectorArgs struct {
 
 // A collection of values returned by getCollector.
 type LookupCollectorResult struct {
-	// Whether the collector is enabled or not
+	// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 	Enabled bool `pulumi:"enabled"`
 	// ID of the collector
 	Id string `pulumi:"id"`
@@ -107,7 +107,7 @@ func (o LookupCollectorResultOutput) ToLookupCollectorResultOutputWithContext(ct
 	return o
 }
 
-// Whether the collector is enabled or not
+// Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 func (o LookupCollectorResultOutput) Enabled() pulumi.BoolOutput {
 	return o.ApplyT(func(v LookupCollectorResult) bool { return v.Enabled }).(pulumi.BoolOutput)
 }

--- a/sdk/go/grafana/getCloudStack.go
+++ b/sdk/go/grafana/getCloudStack.go
@@ -81,6 +81,10 @@ type LookupCloudStackResult struct {
 	Description string `pulumi:"description"`
 	// Name of the Fleet Management instance configured for this stack.
 	FleetManagementName string `pulumi:"fleetManagementName"`
+	// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoPrivateDns string `pulumi:"fleetManagementPrivateConnectivityInfoPrivateDns"`
+	// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+	FleetManagementPrivateConnectivityInfoServiceName string `pulumi:"fleetManagementPrivateConnectivityInfoServiceName"`
 	// Status of the Fleet Management instance configured for this stack.
 	FleetManagementStatus string `pulumi:"fleetManagementStatus"`
 	// Base URL of the Fleet Management instance configured for this stack.
@@ -262,6 +266,16 @@ func (o LookupCloudStackResultOutput) Description() pulumi.StringOutput {
 // Name of the Fleet Management instance configured for this stack.
 func (o LookupCloudStackResultOutput) FleetManagementName() pulumi.StringOutput {
 	return o.ApplyT(func(v LookupCloudStackResult) string { return v.FleetManagementName }).(pulumi.StringOutput)
+}
+
+// Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o LookupCloudStackResultOutput) FleetManagementPrivateConnectivityInfoPrivateDns() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupCloudStackResult) string { return v.FleetManagementPrivateConnectivityInfoPrivateDns }).(pulumi.StringOutput)
+}
+
+// Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+func (o LookupCloudStackResultOutput) FleetManagementPrivateConnectivityInfoServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupCloudStackResult) string { return v.FleetManagementPrivateConnectivityInfoServiceName }).(pulumi.StringOutput)
 }
 
 // Status of the Fleet Management instance configured for this stack.

--- a/sdk/nodejs/cloud/getStack.ts
+++ b/sdk/nodejs/cloud/getStack.ts
@@ -79,6 +79,14 @@ export interface GetStackResult {
      */
     readonly fleetManagementName: string;
     /**
+     * Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    readonly fleetManagementPrivateConnectivityInfoPrivateDns: string;
+    /**
+     * Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    readonly fleetManagementPrivateConnectivityInfoServiceName: string;
+    /**
      * Status of the Fleet Management instance configured for this stack.
      */
     readonly fleetManagementStatus: string;

--- a/sdk/nodejs/cloud/stack.ts
+++ b/sdk/nodejs/cloud/stack.ts
@@ -94,6 +94,14 @@ export class Stack extends pulumi.CustomResource {
      */
     public /*out*/ readonly fleetManagementName!: pulumi.Output<string>;
     /**
+     * Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    public /*out*/ readonly fleetManagementPrivateConnectivityInfoPrivateDns!: pulumi.Output<string>;
+    /**
+     * Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    public /*out*/ readonly fleetManagementPrivateConnectivityInfoServiceName!: pulumi.Output<string>;
+    /**
      * Status of the Fleet Management instance configured for this stack.
      */
     public /*out*/ readonly fleetManagementStatus!: pulumi.Output<string>;
@@ -314,6 +322,8 @@ export class Stack extends pulumi.CustomResource {
             resourceInputs["clusterSlug"] = state ? state.clusterSlug : undefined;
             resourceInputs["description"] = state ? state.description : undefined;
             resourceInputs["fleetManagementName"] = state ? state.fleetManagementName : undefined;
+            resourceInputs["fleetManagementPrivateConnectivityInfoPrivateDns"] = state ? state.fleetManagementPrivateConnectivityInfoPrivateDns : undefined;
+            resourceInputs["fleetManagementPrivateConnectivityInfoServiceName"] = state ? state.fleetManagementPrivateConnectivityInfoServiceName : undefined;
             resourceInputs["fleetManagementStatus"] = state ? state.fleetManagementStatus : undefined;
             resourceInputs["fleetManagementUrl"] = state ? state.fleetManagementUrl : undefined;
             resourceInputs["fleetManagementUserId"] = state ? state.fleetManagementUserId : undefined;
@@ -395,6 +405,8 @@ export class Stack extends pulumi.CustomResource {
             resourceInputs["alertmanagerUserId"] = undefined /*out*/;
             resourceInputs["clusterSlug"] = undefined /*out*/;
             resourceInputs["fleetManagementName"] = undefined /*out*/;
+            resourceInputs["fleetManagementPrivateConnectivityInfoPrivateDns"] = undefined /*out*/;
+            resourceInputs["fleetManagementPrivateConnectivityInfoServiceName"] = undefined /*out*/;
             resourceInputs["fleetManagementStatus"] = undefined /*out*/;
             resourceInputs["fleetManagementUrl"] = undefined /*out*/;
             resourceInputs["fleetManagementUserId"] = undefined /*out*/;
@@ -493,6 +505,14 @@ export interface StackState {
      * Name of the Fleet Management instance configured for this stack.
      */
     fleetManagementName?: pulumi.Input<string>;
+    /**
+     * Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    fleetManagementPrivateConnectivityInfoPrivateDns?: pulumi.Input<string>;
+    /**
+     * Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    fleetManagementPrivateConnectivityInfoServiceName?: pulumi.Input<string>;
     /**
      * Status of the Fleet Management instance configured for this stack.
      */

--- a/sdk/nodejs/cloudStack.ts
+++ b/sdk/nodejs/cloudStack.ts
@@ -97,6 +97,14 @@ export class CloudStack extends pulumi.CustomResource {
      */
     public /*out*/ readonly fleetManagementName!: pulumi.Output<string>;
     /**
+     * Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    public /*out*/ readonly fleetManagementPrivateConnectivityInfoPrivateDns!: pulumi.Output<string>;
+    /**
+     * Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    public /*out*/ readonly fleetManagementPrivateConnectivityInfoServiceName!: pulumi.Output<string>;
+    /**
      * Status of the Fleet Management instance configured for this stack.
      */
     public /*out*/ readonly fleetManagementStatus!: pulumi.Output<string>;
@@ -320,6 +328,8 @@ export class CloudStack extends pulumi.CustomResource {
             resourceInputs["clusterSlug"] = state ? state.clusterSlug : undefined;
             resourceInputs["description"] = state ? state.description : undefined;
             resourceInputs["fleetManagementName"] = state ? state.fleetManagementName : undefined;
+            resourceInputs["fleetManagementPrivateConnectivityInfoPrivateDns"] = state ? state.fleetManagementPrivateConnectivityInfoPrivateDns : undefined;
+            resourceInputs["fleetManagementPrivateConnectivityInfoServiceName"] = state ? state.fleetManagementPrivateConnectivityInfoServiceName : undefined;
             resourceInputs["fleetManagementStatus"] = state ? state.fleetManagementStatus : undefined;
             resourceInputs["fleetManagementUrl"] = state ? state.fleetManagementUrl : undefined;
             resourceInputs["fleetManagementUserId"] = state ? state.fleetManagementUserId : undefined;
@@ -401,6 +411,8 @@ export class CloudStack extends pulumi.CustomResource {
             resourceInputs["alertmanagerUserId"] = undefined /*out*/;
             resourceInputs["clusterSlug"] = undefined /*out*/;
             resourceInputs["fleetManagementName"] = undefined /*out*/;
+            resourceInputs["fleetManagementPrivateConnectivityInfoPrivateDns"] = undefined /*out*/;
+            resourceInputs["fleetManagementPrivateConnectivityInfoServiceName"] = undefined /*out*/;
             resourceInputs["fleetManagementStatus"] = undefined /*out*/;
             resourceInputs["fleetManagementUrl"] = undefined /*out*/;
             resourceInputs["fleetManagementUserId"] = undefined /*out*/;
@@ -497,6 +509,14 @@ export interface CloudStackState {
      * Name of the Fleet Management instance configured for this stack.
      */
     fleetManagementName?: pulumi.Input<string>;
+    /**
+     * Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    fleetManagementPrivateConnectivityInfoPrivateDns?: pulumi.Input<string>;
+    /**
+     * Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    fleetManagementPrivateConnectivityInfoServiceName?: pulumi.Input<string>;
     /**
      * Status of the Fleet Management instance configured for this stack.
      */

--- a/sdk/nodejs/enterprise/scimConfig.ts
+++ b/sdk/nodejs/enterprise/scimConfig.ts
@@ -9,6 +9,19 @@ import * as utilities from "../utilities";
  *
  * * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)
  *
+ * ## Example Usage
+ *
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as grafana from "@pulumiverse/grafana";
+ *
+ * const _default = new grafana.enterprise.ScimConfig("default", {
+ *     enableUserSync: true,
+ *     enableGroupSync: false,
+ *     allowNonProvisionedUsers: false,
+ * });
+ * ```
+ *
  * ## Import
  *
  * ```sh
@@ -48,6 +61,10 @@ export class ScimConfig extends pulumi.CustomResource {
     }
 
     /**
+     * Whether to allow non-provisioned users to access Grafana.
+     */
+    public readonly allowNonProvisionedUsers!: pulumi.Output<boolean>;
+    /**
      * Whether group synchronization is enabled.
      */
     public readonly enableGroupSync!: pulumi.Output<boolean>;
@@ -73,17 +90,22 @@ export class ScimConfig extends pulumi.CustomResource {
         opts = opts || {};
         if (opts.id) {
             const state = argsOrState as ScimConfigState | undefined;
+            resourceInputs["allowNonProvisionedUsers"] = state ? state.allowNonProvisionedUsers : undefined;
             resourceInputs["enableGroupSync"] = state ? state.enableGroupSync : undefined;
             resourceInputs["enableUserSync"] = state ? state.enableUserSync : undefined;
             resourceInputs["orgId"] = state ? state.orgId : undefined;
         } else {
             const args = argsOrState as ScimConfigArgs | undefined;
+            if ((!args || args.allowNonProvisionedUsers === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'allowNonProvisionedUsers'");
+            }
             if ((!args || args.enableGroupSync === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'enableGroupSync'");
             }
             if ((!args || args.enableUserSync === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'enableUserSync'");
             }
+            resourceInputs["allowNonProvisionedUsers"] = args ? args.allowNonProvisionedUsers : undefined;
             resourceInputs["enableGroupSync"] = args ? args.enableGroupSync : undefined;
             resourceInputs["enableUserSync"] = args ? args.enableUserSync : undefined;
             resourceInputs["orgId"] = args ? args.orgId : undefined;
@@ -97,6 +119,10 @@ export class ScimConfig extends pulumi.CustomResource {
  * Input properties used for looking up and filtering ScimConfig resources.
  */
 export interface ScimConfigState {
+    /**
+     * Whether to allow non-provisioned users to access Grafana.
+     */
+    allowNonProvisionedUsers?: pulumi.Input<boolean>;
     /**
      * Whether group synchronization is enabled.
      */
@@ -115,6 +141,10 @@ export interface ScimConfigState {
  * The set of arguments for constructing a ScimConfig resource.
  */
 export interface ScimConfigArgs {
+    /**
+     * Whether to allow non-provisioned users to access Grafana.
+     */
+    allowNonProvisionedUsers: pulumi.Input<boolean>;
     /**
      * Whether group synchronization is enabled.
      */

--- a/sdk/nodejs/fleetmanagement/collector.ts
+++ b/sdk/nodejs/fleetmanagement/collector.ts
@@ -50,7 +50,7 @@ export class Collector extends pulumi.CustomResource {
     }
 
     /**
-     * Whether the collector is enabled or not
+     * Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
      */
     public readonly enabled!: pulumi.Output<boolean>;
     /**
@@ -88,7 +88,7 @@ export class Collector extends pulumi.CustomResource {
  */
 export interface CollectorState {
     /**
-     * Whether the collector is enabled or not
+     * Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
      */
     enabled?: pulumi.Input<boolean>;
     /**
@@ -102,7 +102,7 @@ export interface CollectorState {
  */
 export interface CollectorArgs {
     /**
-     * Whether the collector is enabled or not
+     * Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
      */
     enabled?: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/fleetmanagement/getCollector.ts
+++ b/sdk/nodejs/fleetmanagement/getCollector.ts
@@ -47,7 +47,7 @@ export interface GetCollectorArgs {
  */
 export interface GetCollectorResult {
     /**
-     * Whether the collector is enabled or not
+     * Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
      */
     readonly enabled: boolean;
     /**

--- a/sdk/nodejs/getCloudStack.ts
+++ b/sdk/nodejs/getCloudStack.ts
@@ -81,6 +81,14 @@ export interface GetCloudStackResult {
      */
     readonly fleetManagementName: string;
     /**
+     * Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    readonly fleetManagementPrivateConnectivityInfoPrivateDns: string;
+    /**
+     * Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+     */
+    readonly fleetManagementPrivateConnectivityInfoServiceName: string;
+    /**
      * Status of the Fleet Management instance configured for this stack.
      */
     readonly fleetManagementStatus: string;

--- a/sdk/python/pulumiverse_grafana/cloud/get_stack.py
+++ b/sdk/python/pulumiverse_grafana/cloud/get_stack.py
@@ -27,7 +27,7 @@ class GetStackResult:
     """
     A collection of values returned by getStack.
     """
-    def __init__(__self__, alertmanager_ip_allow_list_cname=None, alertmanager_name=None, alertmanager_status=None, alertmanager_url=None, alertmanager_user_id=None, cluster_slug=None, description=None, fleet_management_name=None, fleet_management_status=None, fleet_management_url=None, fleet_management_user_id=None, grafanas_ip_allow_list_cname=None, graphite_ip_allow_list_cname=None, graphite_name=None, graphite_private_connectivity_info_private_dns=None, graphite_private_connectivity_info_service_name=None, graphite_status=None, graphite_url=None, graphite_user_id=None, id=None, influx_url=None, labels=None, logs_ip_allow_list_cname=None, logs_name=None, logs_private_connectivity_info_private_dns=None, logs_private_connectivity_info_service_name=None, logs_status=None, logs_url=None, logs_user_id=None, name=None, oncall_api_url=None, org_id=None, org_name=None, org_slug=None, otlp_private_connectivity_info_private_dns=None, otlp_private_connectivity_info_service_name=None, otlp_url=None, pdc_api_private_connectivity_info_private_dns=None, pdc_api_private_connectivity_info_service_name=None, pdc_gateway_private_connectivity_info_private_dns=None, pdc_gateway_private_connectivity_info_service_name=None, profiles_ip_allow_list_cname=None, profiles_name=None, profiles_private_connectivity_info_private_dns=None, profiles_private_connectivity_info_service_name=None, profiles_status=None, profiles_url=None, profiles_user_id=None, prometheus_ip_allow_list_cname=None, prometheus_name=None, prometheus_private_connectivity_info_private_dns=None, prometheus_private_connectivity_info_service_name=None, prometheus_remote_endpoint=None, prometheus_remote_write_endpoint=None, prometheus_status=None, prometheus_url=None, prometheus_user_id=None, region_slug=None, slug=None, status=None, traces_ip_allow_list_cname=None, traces_name=None, traces_private_connectivity_info_private_dns=None, traces_private_connectivity_info_service_name=None, traces_status=None, traces_url=None, traces_user_id=None, url=None):
+    def __init__(__self__, alertmanager_ip_allow_list_cname=None, alertmanager_name=None, alertmanager_status=None, alertmanager_url=None, alertmanager_user_id=None, cluster_slug=None, description=None, fleet_management_name=None, fleet_management_private_connectivity_info_private_dns=None, fleet_management_private_connectivity_info_service_name=None, fleet_management_status=None, fleet_management_url=None, fleet_management_user_id=None, grafanas_ip_allow_list_cname=None, graphite_ip_allow_list_cname=None, graphite_name=None, graphite_private_connectivity_info_private_dns=None, graphite_private_connectivity_info_service_name=None, graphite_status=None, graphite_url=None, graphite_user_id=None, id=None, influx_url=None, labels=None, logs_ip_allow_list_cname=None, logs_name=None, logs_private_connectivity_info_private_dns=None, logs_private_connectivity_info_service_name=None, logs_status=None, logs_url=None, logs_user_id=None, name=None, oncall_api_url=None, org_id=None, org_name=None, org_slug=None, otlp_private_connectivity_info_private_dns=None, otlp_private_connectivity_info_service_name=None, otlp_url=None, pdc_api_private_connectivity_info_private_dns=None, pdc_api_private_connectivity_info_service_name=None, pdc_gateway_private_connectivity_info_private_dns=None, pdc_gateway_private_connectivity_info_service_name=None, profiles_ip_allow_list_cname=None, profiles_name=None, profiles_private_connectivity_info_private_dns=None, profiles_private_connectivity_info_service_name=None, profiles_status=None, profiles_url=None, profiles_user_id=None, prometheus_ip_allow_list_cname=None, prometheus_name=None, prometheus_private_connectivity_info_private_dns=None, prometheus_private_connectivity_info_service_name=None, prometheus_remote_endpoint=None, prometheus_remote_write_endpoint=None, prometheus_status=None, prometheus_url=None, prometheus_user_id=None, region_slug=None, slug=None, status=None, traces_ip_allow_list_cname=None, traces_name=None, traces_private_connectivity_info_private_dns=None, traces_private_connectivity_info_service_name=None, traces_status=None, traces_url=None, traces_user_id=None, url=None):
         if alertmanager_ip_allow_list_cname and not isinstance(alertmanager_ip_allow_list_cname, str):
             raise TypeError("Expected argument 'alertmanager_ip_allow_list_cname' to be a str")
         pulumi.set(__self__, "alertmanager_ip_allow_list_cname", alertmanager_ip_allow_list_cname)
@@ -52,6 +52,12 @@ class GetStackResult:
         if fleet_management_name and not isinstance(fleet_management_name, str):
             raise TypeError("Expected argument 'fleet_management_name' to be a str")
         pulumi.set(__self__, "fleet_management_name", fleet_management_name)
+        if fleet_management_private_connectivity_info_private_dns and not isinstance(fleet_management_private_connectivity_info_private_dns, str):
+            raise TypeError("Expected argument 'fleet_management_private_connectivity_info_private_dns' to be a str")
+        pulumi.set(__self__, "fleet_management_private_connectivity_info_private_dns", fleet_management_private_connectivity_info_private_dns)
+        if fleet_management_private_connectivity_info_service_name and not isinstance(fleet_management_private_connectivity_info_service_name, str):
+            raise TypeError("Expected argument 'fleet_management_private_connectivity_info_service_name' to be a str")
+        pulumi.set(__self__, "fleet_management_private_connectivity_info_service_name", fleet_management_private_connectivity_info_service_name)
         if fleet_management_status and not isinstance(fleet_management_status, str):
             raise TypeError("Expected argument 'fleet_management_status' to be a str")
         pulumi.set(__self__, "fleet_management_status", fleet_management_status)
@@ -296,6 +302,22 @@ class GetStackResult:
         Name of the Fleet Management instance configured for this stack.
         """
         return pulumi.get(self, "fleet_management_name")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoPrivateDns")
+    def fleet_management_private_connectivity_info_private_dns(self) -> builtins.str:
+        """
+        Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_private_dns")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoServiceName")
+    def fleet_management_private_connectivity_info_service_name(self) -> builtins.str:
+        """
+        Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_service_name")
 
     @property
     @pulumi.getter(name="fleetManagementStatus")
@@ -748,6 +770,8 @@ class AwaitableGetStackResult(GetStackResult):
             cluster_slug=self.cluster_slug,
             description=self.description,
             fleet_management_name=self.fleet_management_name,
+            fleet_management_private_connectivity_info_private_dns=self.fleet_management_private_connectivity_info_private_dns,
+            fleet_management_private_connectivity_info_service_name=self.fleet_management_private_connectivity_info_service_name,
             fleet_management_status=self.fleet_management_status,
             fleet_management_url=self.fleet_management_url,
             fleet_management_user_id=self.fleet_management_user_id,
@@ -848,6 +872,8 @@ def get_stack(slug: Optional[builtins.str] = None,
         cluster_slug=pulumi.get(__ret__, 'cluster_slug'),
         description=pulumi.get(__ret__, 'description'),
         fleet_management_name=pulumi.get(__ret__, 'fleet_management_name'),
+        fleet_management_private_connectivity_info_private_dns=pulumi.get(__ret__, 'fleet_management_private_connectivity_info_private_dns'),
+        fleet_management_private_connectivity_info_service_name=pulumi.get(__ret__, 'fleet_management_private_connectivity_info_service_name'),
         fleet_management_status=pulumi.get(__ret__, 'fleet_management_status'),
         fleet_management_url=pulumi.get(__ret__, 'fleet_management_url'),
         fleet_management_user_id=pulumi.get(__ret__, 'fleet_management_user_id'),
@@ -945,6 +971,8 @@ def get_stack_output(slug: Optional[pulumi.Input[builtins.str]] = None,
         cluster_slug=pulumi.get(__response__, 'cluster_slug'),
         description=pulumi.get(__response__, 'description'),
         fleet_management_name=pulumi.get(__response__, 'fleet_management_name'),
+        fleet_management_private_connectivity_info_private_dns=pulumi.get(__response__, 'fleet_management_private_connectivity_info_private_dns'),
+        fleet_management_private_connectivity_info_service_name=pulumi.get(__response__, 'fleet_management_private_connectivity_info_service_name'),
         fleet_management_status=pulumi.get(__response__, 'fleet_management_status'),
         fleet_management_url=pulumi.get(__response__, 'fleet_management_url'),
         fleet_management_user_id=pulumi.get(__response__, 'fleet_management_user_id'),

--- a/sdk/python/pulumiverse_grafana/cloud/stack.py
+++ b/sdk/python/pulumiverse_grafana/cloud/stack.py
@@ -163,6 +163,8 @@ class _StackState:
                  cluster_slug: Optional[pulumi.Input[builtins.str]] = None,
                  description: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_name: Optional[pulumi.Input[builtins.str]] = None,
+                 fleet_management_private_connectivity_info_private_dns: Optional[pulumi.Input[builtins.str]] = None,
+                 fleet_management_private_connectivity_info_service_name: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_status: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_url: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_user_id: Optional[pulumi.Input[builtins.int]] = None,
@@ -234,6 +236,8 @@ class _StackState:
         :param pulumi.Input[builtins.str] cluster_slug: Slug of the cluster where this stack resides.
         :param pulumi.Input[builtins.str] description: Description of stack.
         :param pulumi.Input[builtins.str] fleet_management_name: Name of the Fleet Management instance configured for this stack.
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_private_dns: Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_service_name: Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
         :param pulumi.Input[builtins.str] fleet_management_status: Status of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.str] fleet_management_url: Base URL of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.int] fleet_management_user_id: User ID of the Fleet Management instance configured for this stack.
@@ -297,6 +301,10 @@ class _StackState:
             pulumi.set(__self__, "description", description)
         if fleet_management_name is not None:
             pulumi.set(__self__, "fleet_management_name", fleet_management_name)
+        if fleet_management_private_connectivity_info_private_dns is not None:
+            pulumi.set(__self__, "fleet_management_private_connectivity_info_private_dns", fleet_management_private_connectivity_info_private_dns)
+        if fleet_management_private_connectivity_info_service_name is not None:
+            pulumi.set(__self__, "fleet_management_private_connectivity_info_service_name", fleet_management_private_connectivity_info_service_name)
         if fleet_management_status is not None:
             pulumi.set(__self__, "fleet_management_status", fleet_management_status)
         if fleet_management_url is not None:
@@ -515,6 +523,30 @@ class _StackState:
     @fleet_management_name.setter
     def fleet_management_name(self, value: Optional[pulumi.Input[builtins.str]]):
         pulumi.set(self, "fleet_management_name", value)
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoPrivateDns")
+    def fleet_management_private_connectivity_info_private_dns(self) -> Optional[pulumi.Input[builtins.str]]:
+        """
+        Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_private_dns")
+
+    @fleet_management_private_connectivity_info_private_dns.setter
+    def fleet_management_private_connectivity_info_private_dns(self, value: Optional[pulumi.Input[builtins.str]]):
+        pulumi.set(self, "fleet_management_private_connectivity_info_private_dns", value)
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoServiceName")
+    def fleet_management_private_connectivity_info_service_name(self) -> Optional[pulumi.Input[builtins.str]]:
+        """
+        Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_service_name")
+
+    @fleet_management_private_connectivity_info_service_name.setter
+    def fleet_management_private_connectivity_info_service_name(self, value: Optional[pulumi.Input[builtins.str]]):
+        pulumi.set(self, "fleet_management_private_connectivity_info_service_name", value)
 
     @property
     @pulumi.getter(name="fleetManagementStatus")
@@ -1341,6 +1373,8 @@ class Stack(pulumi.CustomResource):
             __props__.__dict__["alertmanager_user_id"] = None
             __props__.__dict__["cluster_slug"] = None
             __props__.__dict__["fleet_management_name"] = None
+            __props__.__dict__["fleet_management_private_connectivity_info_private_dns"] = None
+            __props__.__dict__["fleet_management_private_connectivity_info_service_name"] = None
             __props__.__dict__["fleet_management_status"] = None
             __props__.__dict__["fleet_management_url"] = None
             __props__.__dict__["fleet_management_user_id"] = None
@@ -1415,6 +1449,8 @@ class Stack(pulumi.CustomResource):
             cluster_slug: Optional[pulumi.Input[builtins.str]] = None,
             description: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_name: Optional[pulumi.Input[builtins.str]] = None,
+            fleet_management_private_connectivity_info_private_dns: Optional[pulumi.Input[builtins.str]] = None,
+            fleet_management_private_connectivity_info_service_name: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_status: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_url: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_user_id: Optional[pulumi.Input[builtins.int]] = None,
@@ -1491,6 +1527,8 @@ class Stack(pulumi.CustomResource):
         :param pulumi.Input[builtins.str] cluster_slug: Slug of the cluster where this stack resides.
         :param pulumi.Input[builtins.str] description: Description of stack.
         :param pulumi.Input[builtins.str] fleet_management_name: Name of the Fleet Management instance configured for this stack.
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_private_dns: Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_service_name: Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
         :param pulumi.Input[builtins.str] fleet_management_status: Status of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.str] fleet_management_url: Base URL of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.int] fleet_management_user_id: User ID of the Fleet Management instance configured for this stack.
@@ -1550,6 +1588,8 @@ class Stack(pulumi.CustomResource):
         __props__.__dict__["cluster_slug"] = cluster_slug
         __props__.__dict__["description"] = description
         __props__.__dict__["fleet_management_name"] = fleet_management_name
+        __props__.__dict__["fleet_management_private_connectivity_info_private_dns"] = fleet_management_private_connectivity_info_private_dns
+        __props__.__dict__["fleet_management_private_connectivity_info_service_name"] = fleet_management_private_connectivity_info_service_name
         __props__.__dict__["fleet_management_status"] = fleet_management_status
         __props__.__dict__["fleet_management_url"] = fleet_management_url
         __props__.__dict__["fleet_management_user_id"] = fleet_management_user_id
@@ -1676,6 +1716,22 @@ class Stack(pulumi.CustomResource):
         Name of the Fleet Management instance configured for this stack.
         """
         return pulumi.get(self, "fleet_management_name")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoPrivateDns")
+    def fleet_management_private_connectivity_info_private_dns(self) -> pulumi.Output[builtins.str]:
+        """
+        Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_private_dns")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoServiceName")
+    def fleet_management_private_connectivity_info_service_name(self) -> pulumi.Output[builtins.str]:
+        """
+        Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_service_name")
 
     @property
     @pulumi.getter(name="fleetManagementStatus")

--- a/sdk/python/pulumiverse_grafana/cloud_stack.py
+++ b/sdk/python/pulumiverse_grafana/cloud_stack.py
@@ -163,6 +163,8 @@ class _CloudStackState:
                  cluster_slug: Optional[pulumi.Input[builtins.str]] = None,
                  description: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_name: Optional[pulumi.Input[builtins.str]] = None,
+                 fleet_management_private_connectivity_info_private_dns: Optional[pulumi.Input[builtins.str]] = None,
+                 fleet_management_private_connectivity_info_service_name: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_status: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_url: Optional[pulumi.Input[builtins.str]] = None,
                  fleet_management_user_id: Optional[pulumi.Input[builtins.int]] = None,
@@ -234,6 +236,8 @@ class _CloudStackState:
         :param pulumi.Input[builtins.str] cluster_slug: Slug of the cluster where this stack resides.
         :param pulumi.Input[builtins.str] description: Description of stack.
         :param pulumi.Input[builtins.str] fleet_management_name: Name of the Fleet Management instance configured for this stack.
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_private_dns: Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_service_name: Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
         :param pulumi.Input[builtins.str] fleet_management_status: Status of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.str] fleet_management_url: Base URL of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.int] fleet_management_user_id: User ID of the Fleet Management instance configured for this stack.
@@ -297,6 +301,10 @@ class _CloudStackState:
             pulumi.set(__self__, "description", description)
         if fleet_management_name is not None:
             pulumi.set(__self__, "fleet_management_name", fleet_management_name)
+        if fleet_management_private_connectivity_info_private_dns is not None:
+            pulumi.set(__self__, "fleet_management_private_connectivity_info_private_dns", fleet_management_private_connectivity_info_private_dns)
+        if fleet_management_private_connectivity_info_service_name is not None:
+            pulumi.set(__self__, "fleet_management_private_connectivity_info_service_name", fleet_management_private_connectivity_info_service_name)
         if fleet_management_status is not None:
             pulumi.set(__self__, "fleet_management_status", fleet_management_status)
         if fleet_management_url is not None:
@@ -515,6 +523,30 @@ class _CloudStackState:
     @fleet_management_name.setter
     def fleet_management_name(self, value: Optional[pulumi.Input[builtins.str]]):
         pulumi.set(self, "fleet_management_name", value)
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoPrivateDns")
+    def fleet_management_private_connectivity_info_private_dns(self) -> Optional[pulumi.Input[builtins.str]]:
+        """
+        Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_private_dns")
+
+    @fleet_management_private_connectivity_info_private_dns.setter
+    def fleet_management_private_connectivity_info_private_dns(self, value: Optional[pulumi.Input[builtins.str]]):
+        pulumi.set(self, "fleet_management_private_connectivity_info_private_dns", value)
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoServiceName")
+    def fleet_management_private_connectivity_info_service_name(self) -> Optional[pulumi.Input[builtins.str]]:
+        """
+        Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_service_name")
+
+    @fleet_management_private_connectivity_info_service_name.setter
+    def fleet_management_private_connectivity_info_service_name(self, value: Optional[pulumi.Input[builtins.str]]):
+        pulumi.set(self, "fleet_management_private_connectivity_info_service_name", value)
 
     @property
     @pulumi.getter(name="fleetManagementStatus")
@@ -1347,6 +1379,8 @@ class CloudStack(pulumi.CustomResource):
             __props__.__dict__["alertmanager_user_id"] = None
             __props__.__dict__["cluster_slug"] = None
             __props__.__dict__["fleet_management_name"] = None
+            __props__.__dict__["fleet_management_private_connectivity_info_private_dns"] = None
+            __props__.__dict__["fleet_management_private_connectivity_info_service_name"] = None
             __props__.__dict__["fleet_management_status"] = None
             __props__.__dict__["fleet_management_url"] = None
             __props__.__dict__["fleet_management_user_id"] = None
@@ -1419,6 +1453,8 @@ class CloudStack(pulumi.CustomResource):
             cluster_slug: Optional[pulumi.Input[builtins.str]] = None,
             description: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_name: Optional[pulumi.Input[builtins.str]] = None,
+            fleet_management_private_connectivity_info_private_dns: Optional[pulumi.Input[builtins.str]] = None,
+            fleet_management_private_connectivity_info_service_name: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_status: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_url: Optional[pulumi.Input[builtins.str]] = None,
             fleet_management_user_id: Optional[pulumi.Input[builtins.int]] = None,
@@ -1495,6 +1531,8 @@ class CloudStack(pulumi.CustomResource):
         :param pulumi.Input[builtins.str] cluster_slug: Slug of the cluster where this stack resides.
         :param pulumi.Input[builtins.str] description: Description of stack.
         :param pulumi.Input[builtins.str] fleet_management_name: Name of the Fleet Management instance configured for this stack.
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_private_dns: Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        :param pulumi.Input[builtins.str] fleet_management_private_connectivity_info_service_name: Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
         :param pulumi.Input[builtins.str] fleet_management_status: Status of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.str] fleet_management_url: Base URL of the Fleet Management instance configured for this stack.
         :param pulumi.Input[builtins.int] fleet_management_user_id: User ID of the Fleet Management instance configured for this stack.
@@ -1554,6 +1592,8 @@ class CloudStack(pulumi.CustomResource):
         __props__.__dict__["cluster_slug"] = cluster_slug
         __props__.__dict__["description"] = description
         __props__.__dict__["fleet_management_name"] = fleet_management_name
+        __props__.__dict__["fleet_management_private_connectivity_info_private_dns"] = fleet_management_private_connectivity_info_private_dns
+        __props__.__dict__["fleet_management_private_connectivity_info_service_name"] = fleet_management_private_connectivity_info_service_name
         __props__.__dict__["fleet_management_status"] = fleet_management_status
         __props__.__dict__["fleet_management_url"] = fleet_management_url
         __props__.__dict__["fleet_management_user_id"] = fleet_management_user_id
@@ -1680,6 +1720,22 @@ class CloudStack(pulumi.CustomResource):
         Name of the Fleet Management instance configured for this stack.
         """
         return pulumi.get(self, "fleet_management_name")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoPrivateDns")
+    def fleet_management_private_connectivity_info_private_dns(self) -> pulumi.Output[builtins.str]:
+        """
+        Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_private_dns")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoServiceName")
+    def fleet_management_private_connectivity_info_service_name(self) -> pulumi.Output[builtins.str]:
+        """
+        Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_service_name")
 
     @property
     @pulumi.getter(name="fleetManagementStatus")

--- a/sdk/python/pulumiverse_grafana/enterprise/scim_config.py
+++ b/sdk/python/pulumiverse_grafana/enterprise/scim_config.py
@@ -20,19 +20,34 @@ __all__ = ['ScimConfigArgs', 'ScimConfig']
 @pulumi.input_type
 class ScimConfigArgs:
     def __init__(__self__, *,
+                 allow_non_provisioned_users: pulumi.Input[builtins.bool],
                  enable_group_sync: pulumi.Input[builtins.bool],
                  enable_user_sync: pulumi.Input[builtins.bool],
                  org_id: Optional[pulumi.Input[builtins.str]] = None):
         """
         The set of arguments for constructing a ScimConfig resource.
+        :param pulumi.Input[builtins.bool] allow_non_provisioned_users: Whether to allow non-provisioned users to access Grafana.
         :param pulumi.Input[builtins.bool] enable_group_sync: Whether group synchronization is enabled.
         :param pulumi.Input[builtins.bool] enable_user_sync: Whether user synchronization is enabled.
         :param pulumi.Input[builtins.str] org_id: The Organization ID. If not set, the Org ID defined in the provider block will be used.
         """
+        pulumi.set(__self__, "allow_non_provisioned_users", allow_non_provisioned_users)
         pulumi.set(__self__, "enable_group_sync", enable_group_sync)
         pulumi.set(__self__, "enable_user_sync", enable_user_sync)
         if org_id is not None:
             pulumi.set(__self__, "org_id", org_id)
+
+    @property
+    @pulumi.getter(name="allowNonProvisionedUsers")
+    def allow_non_provisioned_users(self) -> pulumi.Input[builtins.bool]:
+        """
+        Whether to allow non-provisioned users to access Grafana.
+        """
+        return pulumi.get(self, "allow_non_provisioned_users")
+
+    @allow_non_provisioned_users.setter
+    def allow_non_provisioned_users(self, value: pulumi.Input[builtins.bool]):
+        pulumi.set(self, "allow_non_provisioned_users", value)
 
     @property
     @pulumi.getter(name="enableGroupSync")
@@ -74,21 +89,37 @@ class ScimConfigArgs:
 @pulumi.input_type
 class _ScimConfigState:
     def __init__(__self__, *,
+                 allow_non_provisioned_users: Optional[pulumi.Input[builtins.bool]] = None,
                  enable_group_sync: Optional[pulumi.Input[builtins.bool]] = None,
                  enable_user_sync: Optional[pulumi.Input[builtins.bool]] = None,
                  org_id: Optional[pulumi.Input[builtins.str]] = None):
         """
         Input properties used for looking up and filtering ScimConfig resources.
+        :param pulumi.Input[builtins.bool] allow_non_provisioned_users: Whether to allow non-provisioned users to access Grafana.
         :param pulumi.Input[builtins.bool] enable_group_sync: Whether group synchronization is enabled.
         :param pulumi.Input[builtins.bool] enable_user_sync: Whether user synchronization is enabled.
         :param pulumi.Input[builtins.str] org_id: The Organization ID. If not set, the Org ID defined in the provider block will be used.
         """
+        if allow_non_provisioned_users is not None:
+            pulumi.set(__self__, "allow_non_provisioned_users", allow_non_provisioned_users)
         if enable_group_sync is not None:
             pulumi.set(__self__, "enable_group_sync", enable_group_sync)
         if enable_user_sync is not None:
             pulumi.set(__self__, "enable_user_sync", enable_user_sync)
         if org_id is not None:
             pulumi.set(__self__, "org_id", org_id)
+
+    @property
+    @pulumi.getter(name="allowNonProvisionedUsers")
+    def allow_non_provisioned_users(self) -> Optional[pulumi.Input[builtins.bool]]:
+        """
+        Whether to allow non-provisioned users to access Grafana.
+        """
+        return pulumi.get(self, "allow_non_provisioned_users")
+
+    @allow_non_provisioned_users.setter
+    def allow_non_provisioned_users(self, value: Optional[pulumi.Input[builtins.bool]]):
+        pulumi.set(self, "allow_non_provisioned_users", value)
 
     @property
     @pulumi.getter(name="enableGroupSync")
@@ -133,6 +164,7 @@ class ScimConfig(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 allow_non_provisioned_users: Optional[pulumi.Input[builtins.bool]] = None,
                  enable_group_sync: Optional[pulumi.Input[builtins.bool]] = None,
                  enable_user_sync: Optional[pulumi.Input[builtins.bool]] = None,
                  org_id: Optional[pulumi.Input[builtins.str]] = None,
@@ -141,6 +173,18 @@ class ScimConfig(pulumi.CustomResource):
         **Note:** This resource is available only with Grafana Enterprise.
 
         * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)
+
+        ## Example Usage
+
+        ```python
+        import pulumi
+        import pulumiverse_grafana as grafana
+
+        default = grafana.enterprise.ScimConfig("default",
+            enable_user_sync=True,
+            enable_group_sync=False,
+            allow_non_provisioned_users=False)
+        ```
 
         ## Import
 
@@ -154,6 +198,7 @@ class ScimConfig(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[builtins.bool] allow_non_provisioned_users: Whether to allow non-provisioned users to access Grafana.
         :param pulumi.Input[builtins.bool] enable_group_sync: Whether group synchronization is enabled.
         :param pulumi.Input[builtins.bool] enable_user_sync: Whether user synchronization is enabled.
         :param pulumi.Input[builtins.str] org_id: The Organization ID. If not set, the Org ID defined in the provider block will be used.
@@ -168,6 +213,18 @@ class ScimConfig(pulumi.CustomResource):
         **Note:** This resource is available only with Grafana Enterprise.
 
         * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-scim-provisioning/)
+
+        ## Example Usage
+
+        ```python
+        import pulumi
+        import pulumiverse_grafana as grafana
+
+        default = grafana.enterprise.ScimConfig("default",
+            enable_user_sync=True,
+            enable_group_sync=False,
+            allow_non_provisioned_users=False)
+        ```
 
         ## Import
 
@@ -194,6 +251,7 @@ class ScimConfig(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 allow_non_provisioned_users: Optional[pulumi.Input[builtins.bool]] = None,
                  enable_group_sync: Optional[pulumi.Input[builtins.bool]] = None,
                  enable_user_sync: Optional[pulumi.Input[builtins.bool]] = None,
                  org_id: Optional[pulumi.Input[builtins.str]] = None,
@@ -206,6 +264,9 @@ class ScimConfig(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ScimConfigArgs.__new__(ScimConfigArgs)
 
+            if allow_non_provisioned_users is None and not opts.urn:
+                raise TypeError("Missing required property 'allow_non_provisioned_users'")
+            __props__.__dict__["allow_non_provisioned_users"] = allow_non_provisioned_users
             if enable_group_sync is None and not opts.urn:
                 raise TypeError("Missing required property 'enable_group_sync'")
             __props__.__dict__["enable_group_sync"] = enable_group_sync
@@ -223,6 +284,7 @@ class ScimConfig(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
+            allow_non_provisioned_users: Optional[pulumi.Input[builtins.bool]] = None,
             enable_group_sync: Optional[pulumi.Input[builtins.bool]] = None,
             enable_user_sync: Optional[pulumi.Input[builtins.bool]] = None,
             org_id: Optional[pulumi.Input[builtins.str]] = None) -> 'ScimConfig':
@@ -233,6 +295,7 @@ class ScimConfig(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[builtins.bool] allow_non_provisioned_users: Whether to allow non-provisioned users to access Grafana.
         :param pulumi.Input[builtins.bool] enable_group_sync: Whether group synchronization is enabled.
         :param pulumi.Input[builtins.bool] enable_user_sync: Whether user synchronization is enabled.
         :param pulumi.Input[builtins.str] org_id: The Organization ID. If not set, the Org ID defined in the provider block will be used.
@@ -241,10 +304,19 @@ class ScimConfig(pulumi.CustomResource):
 
         __props__ = _ScimConfigState.__new__(_ScimConfigState)
 
+        __props__.__dict__["allow_non_provisioned_users"] = allow_non_provisioned_users
         __props__.__dict__["enable_group_sync"] = enable_group_sync
         __props__.__dict__["enable_user_sync"] = enable_user_sync
         __props__.__dict__["org_id"] = org_id
         return ScimConfig(resource_name, opts=opts, __props__=__props__)
+
+    @property
+    @pulumi.getter(name="allowNonProvisionedUsers")
+    def allow_non_provisioned_users(self) -> pulumi.Output[builtins.bool]:
+        """
+        Whether to allow non-provisioned users to access Grafana.
+        """
+        return pulumi.get(self, "allow_non_provisioned_users")
 
     @property
     @pulumi.getter(name="enableGroupSync")

--- a/sdk/python/pulumiverse_grafana/fleetmanagement/collector.py
+++ b/sdk/python/pulumiverse_grafana/fleetmanagement/collector.py
@@ -24,7 +24,7 @@ class CollectorArgs:
                  remote_attributes: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None):
         """
         The set of arguments for constructing a Collector resource.
-        :param pulumi.Input[builtins.bool] enabled: Whether the collector is enabled or not
+        :param pulumi.Input[builtins.bool] enabled: Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] remote_attributes: Remote attributes for the collector
         """
         if enabled is not None:
@@ -36,7 +36,7 @@ class CollectorArgs:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[builtins.bool]]:
         """
-        Whether the collector is enabled or not
+        Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         """
         return pulumi.get(self, "enabled")
 
@@ -64,7 +64,7 @@ class _CollectorState:
                  remote_attributes: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None):
         """
         Input properties used for looking up and filtering Collector resources.
-        :param pulumi.Input[builtins.bool] enabled: Whether the collector is enabled or not
+        :param pulumi.Input[builtins.bool] enabled: Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] remote_attributes: Remote attributes for the collector
         """
         if enabled is not None:
@@ -76,7 +76,7 @@ class _CollectorState:
     @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[builtins.bool]]:
         """
-        Whether the collector is enabled or not
+        Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         """
         return pulumi.get(self, "enabled")
 
@@ -125,7 +125,7 @@ class Collector(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[builtins.bool] enabled: Whether the collector is enabled or not
+        :param pulumi.Input[builtins.bool] enabled: Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] remote_attributes: Remote attributes for the collector
         """
         ...
@@ -198,7 +198,7 @@ class Collector(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[builtins.bool] enabled: Whether the collector is enabled or not
+        :param pulumi.Input[builtins.bool] enabled: Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] remote_attributes: Remote attributes for the collector
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
@@ -213,7 +213,7 @@ class Collector(pulumi.CustomResource):
     @pulumi.getter
     def enabled(self) -> pulumi.Output[builtins.bool]:
         """
-        Whether the collector is enabled or not
+        Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         """
         return pulumi.get(self, "enabled")
 

--- a/sdk/python/pulumiverse_grafana/fleetmanagement/get_collector.py
+++ b/sdk/python/pulumiverse_grafana/fleetmanagement/get_collector.py
@@ -45,7 +45,7 @@ class GetCollectorResult:
     @pulumi.getter
     def enabled(self) -> builtins.bool:
         """
-        Whether the collector is enabled or not
+        Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
         """
         return pulumi.get(self, "enabled")
 

--- a/sdk/python/pulumiverse_grafana/get_cloud_stack.py
+++ b/sdk/python/pulumiverse_grafana/get_cloud_stack.py
@@ -29,7 +29,7 @@ class GetCloudStackResult:
     """
     A collection of values returned by getCloudStack.
     """
-    def __init__(__self__, alertmanager_ip_allow_list_cname=None, alertmanager_name=None, alertmanager_status=None, alertmanager_url=None, alertmanager_user_id=None, cluster_slug=None, description=None, fleet_management_name=None, fleet_management_status=None, fleet_management_url=None, fleet_management_user_id=None, grafanas_ip_allow_list_cname=None, graphite_ip_allow_list_cname=None, graphite_name=None, graphite_private_connectivity_info_private_dns=None, graphite_private_connectivity_info_service_name=None, graphite_status=None, graphite_url=None, graphite_user_id=None, id=None, influx_url=None, labels=None, logs_ip_allow_list_cname=None, logs_name=None, logs_private_connectivity_info_private_dns=None, logs_private_connectivity_info_service_name=None, logs_status=None, logs_url=None, logs_user_id=None, name=None, oncall_api_url=None, org_id=None, org_name=None, org_slug=None, otlp_private_connectivity_info_private_dns=None, otlp_private_connectivity_info_service_name=None, otlp_url=None, pdc_api_private_connectivity_info_private_dns=None, pdc_api_private_connectivity_info_service_name=None, pdc_gateway_private_connectivity_info_private_dns=None, pdc_gateway_private_connectivity_info_service_name=None, profiles_ip_allow_list_cname=None, profiles_name=None, profiles_private_connectivity_info_private_dns=None, profiles_private_connectivity_info_service_name=None, profiles_status=None, profiles_url=None, profiles_user_id=None, prometheus_ip_allow_list_cname=None, prometheus_name=None, prometheus_private_connectivity_info_private_dns=None, prometheus_private_connectivity_info_service_name=None, prometheus_remote_endpoint=None, prometheus_remote_write_endpoint=None, prometheus_status=None, prometheus_url=None, prometheus_user_id=None, region_slug=None, slug=None, status=None, traces_ip_allow_list_cname=None, traces_name=None, traces_private_connectivity_info_private_dns=None, traces_private_connectivity_info_service_name=None, traces_status=None, traces_url=None, traces_user_id=None, url=None):
+    def __init__(__self__, alertmanager_ip_allow_list_cname=None, alertmanager_name=None, alertmanager_status=None, alertmanager_url=None, alertmanager_user_id=None, cluster_slug=None, description=None, fleet_management_name=None, fleet_management_private_connectivity_info_private_dns=None, fleet_management_private_connectivity_info_service_name=None, fleet_management_status=None, fleet_management_url=None, fleet_management_user_id=None, grafanas_ip_allow_list_cname=None, graphite_ip_allow_list_cname=None, graphite_name=None, graphite_private_connectivity_info_private_dns=None, graphite_private_connectivity_info_service_name=None, graphite_status=None, graphite_url=None, graphite_user_id=None, id=None, influx_url=None, labels=None, logs_ip_allow_list_cname=None, logs_name=None, logs_private_connectivity_info_private_dns=None, logs_private_connectivity_info_service_name=None, logs_status=None, logs_url=None, logs_user_id=None, name=None, oncall_api_url=None, org_id=None, org_name=None, org_slug=None, otlp_private_connectivity_info_private_dns=None, otlp_private_connectivity_info_service_name=None, otlp_url=None, pdc_api_private_connectivity_info_private_dns=None, pdc_api_private_connectivity_info_service_name=None, pdc_gateway_private_connectivity_info_private_dns=None, pdc_gateway_private_connectivity_info_service_name=None, profiles_ip_allow_list_cname=None, profiles_name=None, profiles_private_connectivity_info_private_dns=None, profiles_private_connectivity_info_service_name=None, profiles_status=None, profiles_url=None, profiles_user_id=None, prometheus_ip_allow_list_cname=None, prometheus_name=None, prometheus_private_connectivity_info_private_dns=None, prometheus_private_connectivity_info_service_name=None, prometheus_remote_endpoint=None, prometheus_remote_write_endpoint=None, prometheus_status=None, prometheus_url=None, prometheus_user_id=None, region_slug=None, slug=None, status=None, traces_ip_allow_list_cname=None, traces_name=None, traces_private_connectivity_info_private_dns=None, traces_private_connectivity_info_service_name=None, traces_status=None, traces_url=None, traces_user_id=None, url=None):
         if alertmanager_ip_allow_list_cname and not isinstance(alertmanager_ip_allow_list_cname, str):
             raise TypeError("Expected argument 'alertmanager_ip_allow_list_cname' to be a str")
         pulumi.set(__self__, "alertmanager_ip_allow_list_cname", alertmanager_ip_allow_list_cname)
@@ -54,6 +54,12 @@ class GetCloudStackResult:
         if fleet_management_name and not isinstance(fleet_management_name, str):
             raise TypeError("Expected argument 'fleet_management_name' to be a str")
         pulumi.set(__self__, "fleet_management_name", fleet_management_name)
+        if fleet_management_private_connectivity_info_private_dns and not isinstance(fleet_management_private_connectivity_info_private_dns, str):
+            raise TypeError("Expected argument 'fleet_management_private_connectivity_info_private_dns' to be a str")
+        pulumi.set(__self__, "fleet_management_private_connectivity_info_private_dns", fleet_management_private_connectivity_info_private_dns)
+        if fleet_management_private_connectivity_info_service_name and not isinstance(fleet_management_private_connectivity_info_service_name, str):
+            raise TypeError("Expected argument 'fleet_management_private_connectivity_info_service_name' to be a str")
+        pulumi.set(__self__, "fleet_management_private_connectivity_info_service_name", fleet_management_private_connectivity_info_service_name)
         if fleet_management_status and not isinstance(fleet_management_status, str):
             raise TypeError("Expected argument 'fleet_management_status' to be a str")
         pulumi.set(__self__, "fleet_management_status", fleet_management_status)
@@ -298,6 +304,22 @@ class GetCloudStackResult:
         Name of the Fleet Management instance configured for this stack.
         """
         return pulumi.get(self, "fleet_management_name")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoPrivateDns")
+    def fleet_management_private_connectivity_info_private_dns(self) -> builtins.str:
+        """
+        Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_private_dns")
+
+    @property
+    @pulumi.getter(name="fleetManagementPrivateConnectivityInfoServiceName")
+    def fleet_management_private_connectivity_info_service_name(self) -> builtins.str:
+        """
+        Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)
+        """
+        return pulumi.get(self, "fleet_management_private_connectivity_info_service_name")
 
     @property
     @pulumi.getter(name="fleetManagementStatus")
@@ -750,6 +772,8 @@ class AwaitableGetCloudStackResult(GetCloudStackResult):
             cluster_slug=self.cluster_slug,
             description=self.description,
             fleet_management_name=self.fleet_management_name,
+            fleet_management_private_connectivity_info_private_dns=self.fleet_management_private_connectivity_info_private_dns,
+            fleet_management_private_connectivity_info_service_name=self.fleet_management_private_connectivity_info_service_name,
             fleet_management_status=self.fleet_management_status,
             fleet_management_url=self.fleet_management_url,
             fleet_management_user_id=self.fleet_management_user_id,
@@ -851,6 +875,8 @@ def get_cloud_stack(slug: Optional[builtins.str] = None,
         cluster_slug=pulumi.get(__ret__, 'cluster_slug'),
         description=pulumi.get(__ret__, 'description'),
         fleet_management_name=pulumi.get(__ret__, 'fleet_management_name'),
+        fleet_management_private_connectivity_info_private_dns=pulumi.get(__ret__, 'fleet_management_private_connectivity_info_private_dns'),
+        fleet_management_private_connectivity_info_service_name=pulumi.get(__ret__, 'fleet_management_private_connectivity_info_service_name'),
         fleet_management_status=pulumi.get(__ret__, 'fleet_management_status'),
         fleet_management_url=pulumi.get(__ret__, 'fleet_management_url'),
         fleet_management_user_id=pulumi.get(__ret__, 'fleet_management_user_id'),
@@ -949,6 +975,8 @@ def get_cloud_stack_output(slug: Optional[pulumi.Input[builtins.str]] = None,
         cluster_slug=pulumi.get(__response__, 'cluster_slug'),
         description=pulumi.get(__response__, 'description'),
         fleet_management_name=pulumi.get(__response__, 'fleet_management_name'),
+        fleet_management_private_connectivity_info_private_dns=pulumi.get(__response__, 'fleet_management_private_connectivity_info_private_dns'),
+        fleet_management_private_connectivity_info_service_name=pulumi.get(__response__, 'fleet_management_private_connectivity_info_service_name'),
         fleet_management_status=pulumi.get(__response__, 'fleet_management_status'),
         fleet_management_url=pulumi.get(__response__, 'fleet_management_url'),
         fleet_management_user_id=pulumi.get(__response__, 'fleet_management_user_id'),


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-grafana --kind=provider --target-bridge-version=latest --target-version=3.25.8 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-grafana from 3.25.7  to 3.25.8.
	Fixes #293
