### PR TITLE
Upgrade terraform-provider-grafana to v3.25.9

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/grafana/terraform-provider-grafana/v3 v3.25.8
+	github.com/grafana/terraform-provider-grafana/v3 v3.25.9
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.110.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1954,8 +1954,8 @@ github.com/grafana/synthetic-monitoring-agent v0.34.4 h1:2wlf6qJifAMIfc3JnmPamGc
 github.com/grafana/synthetic-monitoring-agent v0.34.4/go.mod h1:V/Wj1omTCRzsK++f9UZ7QK/neZXpP1ESOFkWJ62g5ik=
 github.com/grafana/synthetic-monitoring-api-go-client v0.14.0 h1:XBqG4F5SON1Bz6DwnK4xw2bPny3Y8iv+DF/RYAhL+zQ=
 github.com/grafana/synthetic-monitoring-api-go-client v0.14.0/go.mod h1:+58mGFzv0T/wcBCHPK1NpKpGtsYkeSKRBLH5M89hgBE=
-github.com/grafana/terraform-provider-grafana/v3 v3.25.8 h1:EK6n81sc9IDDEatstUJrbavJDR4SiUY8CErdr0pV2DE=
-github.com/grafana/terraform-provider-grafana/v3 v3.25.8/go.mod h1:zL5rUyvNe4XlFkh9fmfAvpBPt8Ii5tHMHBofkZCV5WE=
+github.com/grafana/terraform-provider-grafana/v3 v3.25.9 h1:KL7ELoHdbfoGsLH5mtE5sQzOKHXn/BARoVW+nX94GWo=
+github.com/grafana/terraform-provider-grafana/v3 v3.25.9/go.mod h1:zL5rUyvNe4XlFkh9fmfAvpBPt8Ii5tHMHBofkZCV5WE=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdixfIJjVzuUJdnv+5xsPutog=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-grafana --kind=provider --target-bridge-version=latest --target-version=3.25.9 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-grafana from 3.25.8  to 3.25.9.
	Fixes #295
