### PR TITLE
Upgrade terraform-provider-grafana to v4.3.0

### DIFF
--- a/provider/cmd/pulumi-resource-grafana/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-grafana/bridge-metadata.json
@@ -819,6 +819,9 @@
                                     "maxItemsOne": true,
                                     "elem": {
                                         "fields": {
+                                            "active_timings": {
+                                                "maxItemsOne": false
+                                            },
                                             "group_by": {
                                                 "maxItemsOne": false
                                             },

--- a/provider/cmd/pulumi-resource-grafana/schema.json
+++ b/provider/cmd/pulumi-resource-grafana/schema.json
@@ -2078,6 +2078,13 @@
         },
         "grafana:alerting/RuleGroupRuleNotificationSettings:RuleGroupRuleNotificationSettings": {
             "properties": {
+                "activeTimings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later\n"
+                },
                 "contactPoint": {
                     "type": "string",
                     "description": "The contact point to route notifications that match this rule to.\n"

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.25
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/grafana/terraform-provider-grafana/v4 v4.2.0
+	github.com/grafana/terraform-provider-grafana/v4 v4.3.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.114.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1964,8 +1964,8 @@ github.com/grafana/synthetic-monitoring-agent v0.43.1 h1:Qejsuf25yZzdImVLZ6K1f5c
 github.com/grafana/synthetic-monitoring-agent v0.43.1/go.mod h1:HO4es33UF/5b3i4JdUhVcvs9abUXESMjFxnWP8y6KG0=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1 h1:6ZQoQVD0sASxe5OVEk/T/YEOYOuilSA434bX4n3SJLQ=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1/go.mod h1:3XfDhlxYkC/Apaug0e0vd4wHx8JZJ4k+v5ybny8ZGfc=
-github.com/grafana/terraform-provider-grafana/v4 v4.2.0 h1:TKbSvNRC9vN//eZbMYmzudOtq9iM5zFQbWgOO3IDOWU=
-github.com/grafana/terraform-provider-grafana/v4 v4.2.0/go.mod h1:LrNDqb0SxQDJqe/VBiQgN2nFNW8fkmuukVxhLmB9jYo=
+github.com/grafana/terraform-provider-grafana/v4 v4.3.0 h1:+dpbUrcg7+aOfTyUw8JkY1bR0mrhp4g9PXCLdqMSd2o=
+github.com/grafana/terraform-provider-grafana/v4 v4.3.0/go.mod h1:LrNDqb0SxQDJqe/VBiQgN2nFNW8fkmuukVxhLmB9jYo=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4zG2vvqG6uWNkBHSTqXOZk0=

--- a/sdk/dotnet/Alerting/Inputs/RuleGroupRuleNotificationSettingsArgs.cs
+++ b/sdk/dotnet/Alerting/Inputs/RuleGroupRuleNotificationSettingsArgs.cs
@@ -13,6 +13,18 @@ namespace Pulumiverse.Grafana.Alerting.Inputs
 
     public sealed class RuleGroupRuleNotificationSettingsArgs : global::Pulumi.ResourceArgs
     {
+        [Input("activeTimings")]
+        private InputList<string>? _activeTimings;
+
+        /// <summary>
+        /// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+        /// </summary>
+        public InputList<string> ActiveTimings
+        {
+            get => _activeTimings ?? (_activeTimings = new InputList<string>());
+            set => _activeTimings = value;
+        }
+
         /// <summary>
         /// The contact point to route notifications that match this rule to.
         /// </summary>

--- a/sdk/dotnet/Alerting/Inputs/RuleGroupRuleNotificationSettingsGetArgs.cs
+++ b/sdk/dotnet/Alerting/Inputs/RuleGroupRuleNotificationSettingsGetArgs.cs
@@ -13,6 +13,18 @@ namespace Pulumiverse.Grafana.Alerting.Inputs
 
     public sealed class RuleGroupRuleNotificationSettingsGetArgs : global::Pulumi.ResourceArgs
     {
+        [Input("activeTimings")]
+        private InputList<string>? _activeTimings;
+
+        /// <summary>
+        /// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+        /// </summary>
+        public InputList<string> ActiveTimings
+        {
+            get => _activeTimings ?? (_activeTimings = new InputList<string>());
+            set => _activeTimings = value;
+        }
+
         /// <summary>
         /// The contact point to route notifications that match this rule to.
         /// </summary>

--- a/sdk/dotnet/Alerting/Outputs/RuleGroupRuleNotificationSettings.cs
+++ b/sdk/dotnet/Alerting/Outputs/RuleGroupRuleNotificationSettings.cs
@@ -15,6 +15,10 @@ namespace Pulumiverse.Grafana.Alerting.Outputs
     public sealed class RuleGroupRuleNotificationSettings
     {
         /// <summary>
+        /// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+        /// </summary>
+        public readonly ImmutableArray<string> ActiveTimings;
+        /// <summary>
         /// The contact point to route notifications that match this rule to.
         /// </summary>
         public readonly string ContactPoint;
@@ -41,6 +45,8 @@ namespace Pulumiverse.Grafana.Alerting.Outputs
 
         [OutputConstructor]
         private RuleGroupRuleNotificationSettings(
+            ImmutableArray<string> activeTimings,
+
             string contactPoint,
 
             ImmutableArray<string> groupBies,
@@ -53,6 +59,7 @@ namespace Pulumiverse.Grafana.Alerting.Outputs
 
             string? repeatInterval)
         {
+            ActiveTimings = activeTimings;
             ContactPoint = contactPoint;
             GroupBies = groupBies;
             GroupInterval = groupInterval;

--- a/sdk/go/grafana/alerting/pulumiTypes.go
+++ b/sdk/go/grafana/alerting/pulumiTypes.go
@@ -5650,6 +5650,8 @@ func (o RuleGroupRuleDataRelativeTimeRangeOutput) To() pulumi.IntOutput {
 }
 
 type RuleGroupRuleNotificationSettings struct {
+	// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+	ActiveTimings []string `pulumi:"activeTimings"`
 	// The contact point to route notifications that match this rule to.
 	ContactPoint string `pulumi:"contactPoint"`
 	// A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
@@ -5676,6 +5678,8 @@ type RuleGroupRuleNotificationSettingsInput interface {
 }
 
 type RuleGroupRuleNotificationSettingsArgs struct {
+	// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+	ActiveTimings pulumi.StringArrayInput `pulumi:"activeTimings"`
 	// The contact point to route notifications that match this rule to.
 	ContactPoint pulumi.StringInput `pulumi:"contactPoint"`
 	// A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
@@ -5767,6 +5771,11 @@ func (o RuleGroupRuleNotificationSettingsOutput) ToRuleGroupRuleNotificationSett
 	}).(RuleGroupRuleNotificationSettingsPtrOutput)
 }
 
+// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+func (o RuleGroupRuleNotificationSettingsOutput) ActiveTimings() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v RuleGroupRuleNotificationSettings) []string { return v.ActiveTimings }).(pulumi.StringArrayOutput)
+}
+
 // The contact point to route notifications that match this rule to.
 func (o RuleGroupRuleNotificationSettingsOutput) ContactPoint() pulumi.StringOutput {
 	return o.ApplyT(func(v RuleGroupRuleNotificationSettings) string { return v.ContactPoint }).(pulumi.StringOutput)
@@ -5819,6 +5828,16 @@ func (o RuleGroupRuleNotificationSettingsPtrOutput) Elem() RuleGroupRuleNotifica
 		var ret RuleGroupRuleNotificationSettings
 		return ret
 	}).(RuleGroupRuleNotificationSettingsOutput)
+}
+
+// A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+func (o RuleGroupRuleNotificationSettingsPtrOutput) ActiveTimings() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *RuleGroupRuleNotificationSettings) []string {
+		if v == nil {
+			return nil
+		}
+		return v.ActiveTimings
+	}).(pulumi.StringArrayOutput)
 }
 
 // The contact point to route notifications that match this rule to.

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -1263,6 +1263,10 @@ export namespace alerting {
 
     export interface RuleGroupRuleNotificationSettings {
         /**
+         * A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+         */
+        activeTimings?: pulumi.Input<pulumi.Input<string>[]>;
+        /**
          * The contact point to route notifications that match this rule to.
          */
         contactPoint: pulumi.Input<string>;

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -1263,6 +1263,10 @@ export namespace alerting {
 
     export interface RuleGroupRuleNotificationSettings {
         /**
+         * A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+         */
+        activeTimings?: string[];
+        /**
          * The contact point to route notifications that match this rule to.
          */
         contactPoint: string;

--- a/sdk/python/pulumiverse_grafana/alerting/_inputs.py
+++ b/sdk/python/pulumiverse_grafana/alerting/_inputs.py
@@ -6237,6 +6237,10 @@ if not MYPY:
         """
         The contact point to route notifications that match this rule to.
         """
+        active_timings: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+        """
+        A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+        """
         group_bies: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
         """
         A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
@@ -6264,6 +6268,7 @@ elif False:
 class RuleGroupRuleNotificationSettingsArgs:
     def __init__(__self__, *,
                  contact_point: pulumi.Input[_builtins.str],
+                 active_timings: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  group_bies: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  group_interval: Optional[pulumi.Input[_builtins.str]] = None,
                  group_wait: Optional[pulumi.Input[_builtins.str]] = None,
@@ -6271,6 +6276,7 @@ class RuleGroupRuleNotificationSettingsArgs:
                  repeat_interval: Optional[pulumi.Input[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] contact_point: The contact point to route notifications that match this rule to.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] active_timings: A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] group_bies: A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
         :param pulumi.Input[_builtins.str] group_interval: Minimum time interval between two notifications for the same group. Default is 5 minutes.
         :param pulumi.Input[_builtins.str] group_wait: Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.
@@ -6278,6 +6284,8 @@ class RuleGroupRuleNotificationSettingsArgs:
         :param pulumi.Input[_builtins.str] repeat_interval: Minimum time interval for re-sending a notification if an alert is still firing. Default is 4 hours.
         """
         pulumi.set(__self__, "contact_point", contact_point)
+        if active_timings is not None:
+            pulumi.set(__self__, "active_timings", active_timings)
         if group_bies is not None:
             pulumi.set(__self__, "group_bies", group_bies)
         if group_interval is not None:
@@ -6300,6 +6308,18 @@ class RuleGroupRuleNotificationSettingsArgs:
     @contact_point.setter
     def contact_point(self, value: pulumi.Input[_builtins.str]):
         pulumi.set(self, "contact_point", value)
+
+    @_builtins.property
+    @pulumi.getter(name="activeTimings")
+    def active_timings(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+        """
+        A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+        """
+        return pulumi.get(self, "active_timings")
+
+    @active_timings.setter
+    def active_timings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+        pulumi.set(self, "active_timings", value)
 
     @_builtins.property
     @pulumi.getter(name="groupBies")

--- a/sdk/python/pulumiverse_grafana/alerting/outputs.py
+++ b/sdk/python/pulumiverse_grafana/alerting/outputs.py
@@ -4414,6 +4414,8 @@ class RuleGroupRuleNotificationSettings(dict):
         suggest = None
         if key == "contactPoint":
             suggest = "contact_point"
+        elif key == "activeTimings":
+            suggest = "active_timings"
         elif key == "groupBies":
             suggest = "group_bies"
         elif key == "groupInterval":
@@ -4438,6 +4440,7 @@ class RuleGroupRuleNotificationSettings(dict):
 
     def __init__(__self__, *,
                  contact_point: _builtins.str,
+                 active_timings: Optional[Sequence[_builtins.str]] = None,
                  group_bies: Optional[Sequence[_builtins.str]] = None,
                  group_interval: Optional[_builtins.str] = None,
                  group_wait: Optional[_builtins.str] = None,
@@ -4445,6 +4448,7 @@ class RuleGroupRuleNotificationSettings(dict):
                  repeat_interval: Optional[_builtins.str] = None):
         """
         :param _builtins.str contact_point: The contact point to route notifications that match this rule to.
+        :param Sequence[_builtins.str] active_timings: A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
         :param Sequence[_builtins.str] group_bies: A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
         :param _builtins.str group_interval: Minimum time interval between two notifications for the same group. Default is 5 minutes.
         :param _builtins.str group_wait: Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.
@@ -4452,6 +4456,8 @@ class RuleGroupRuleNotificationSettings(dict):
         :param _builtins.str repeat_interval: Minimum time interval for re-sending a notification if an alert is still firing. Default is 4 hours.
         """
         pulumi.set(__self__, "contact_point", contact_point)
+        if active_timings is not None:
+            pulumi.set(__self__, "active_timings", active_timings)
         if group_bies is not None:
             pulumi.set(__self__, "group_bies", group_bies)
         if group_interval is not None:
@@ -4470,6 +4476,14 @@ class RuleGroupRuleNotificationSettings(dict):
         The contact point to route notifications that match this rule to.
         """
         return pulumi.get(self, "contact_point")
+
+    @_builtins.property
+    @pulumi.getter(name="activeTimings")
+    def active_timings(self) -> Optional[Sequence[_builtins.str]]:
+        """
+        A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+        """
+        return pulumi.get(self, "active_timings")
 
     @_builtins.property
     @pulumi.getter(name="groupBies")


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-grafana --target-version v4.3.0`.

---

- Upgrading terraform-provider-grafana from 4.2.0  to 4.3.0.
	Fixes #301
